### PR TITLE
Support bash in devenv scripts

### DIFF
--- a/config.inc
+++ b/config.inc
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-HOST_BASE_PREFIX=${HOST_BASE_PREFIX:-$(cd "$(dirname ${0})" && pwd)}
+HOST_BASE_PREFIX=${HOST_BASE_PREFIX:-$(cd "$(dirname ${BASH_SOURCE:-$0})" && pwd)}
 if [ ! -x "${HOST_BASE_PREFIX}/helpers/install.sh" ]; then
     echo "Unable to find the current script base directory" >&2
     exit 1

--- a/devenv_build_container.sh
+++ b/devenv_build_container.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$(dirname ${0})/config.inc"
+. "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
 if docker image inspect lucet-dev:latest > /dev/null; then
 	if [ -z "$DEVENV_FORCE_REBUILD" ]; then

--- a/devenv_run.sh
+++ b/devenv_run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$(dirname ${0})/config.inc"
+. "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
 if ! docker ps -f name=lucet | grep -Fq lucet ; then
 	${HOST_BASE_PREFIX}/devenv_start.sh

--- a/devenv_setenv.sh
+++ b/devenv_setenv.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. $(dirname ${0})/config.inc
+. $(dirname ${BASH_SOURCE:-$0})/config.inc
 
 if ! "$HOST_RUN" true ; then
     echo "Unable to run commands in the container" >&2

--- a/devenv_start.sh
+++ b/devenv_start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$(dirname ${0})/config.inc"
+. "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
 if ! docker image inspect lucet-dev:latest > /dev/null; then
 	${HOST_BASE_PREFIX}/devenv_build_container.sh

--- a/devenv_stop.sh
+++ b/devenv_stop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$(dirname ${0})/config.inc"
+. "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
 echo "Stopping container"
 docker stop lucet


### PR DESCRIPTION
I'm using bash on Ubuntu 18.04 LTS.
Without this modification, I got the following error when running `source devenv_setenv.sh`

```
$ source devenv_setenv.sh
dirname: invalid option -- 'b'
Try 'dirname --help' for more information.
-bash: /config.inc: No such file or directory

Command '' not found, but can be installed with:

sudo apt install libpam-mount
sudo apt install openssh-server
sudo apt install openvswitch-common
sudo apt install openvswitch-switch
sudo apt install php-common
sudo apt install bpfcc-tools
sudo apt install burp
sudo apt install cryptmount
sudo apt install dolphin-emu
sudo apt install mailutils-mh
sudo apt install mmh
sudo apt install nmh

Unable to run commands in the container
```