### PR TITLE
Add CLI configuration for memory limits and improve performance for large initial heaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-runtime 0.1.0",
  "lucet-runtime-internals 0.1.0",

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -388,6 +388,11 @@ impl Limits {
                 "address space size must be a multiple of host page size",
             ));
         }
+        if self.heap_memory_size > self.heap_address_space_size {
+            return Err(Error::InvalidArgument(
+                "address space size must be at least as large as memory size",
+            ));
+        }
         if self.stack_size % host_page_size() != 0 {
             return Err(Error::InvalidArgument(
                 "stack size must be a multiple of host page size",

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -256,6 +256,19 @@ macro_rules! alloc_tests {
             assert!(res.is_err(), "new_instance fails");
         }
 
+        /// This test shows that we reject limits with a larger memory size than address space size
+        #[test]
+        fn reject_undersized_address_space() {
+        const LIMITS: Limits = Limits {
+            heap_memory_size: LIMITS_HEAP_ADDRSPACE_SIZE + 4096,
+            heap_address_space_size: LIMITS_HEAP_ADDRSPACE_SIZE,
+            stack_size: LIMITS_STACK_SIZE,
+            globals_size: LIMITS_GLOBALS_SIZE,
+        };
+            let res = TestRegion::create(10, &LIMITS);
+            assert!(res.is_err(), "region creation fails");
+        }
+
         const SMALL_GUARD_HEAP: HeapSpec = HeapSpec {
             reserved_size: SPEC_HEAP_RESERVED_SIZE,
             guard_size: SPEC_HEAP_GUARD_SIZE - 1,

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -259,12 +259,12 @@ macro_rules! alloc_tests {
         /// This test shows that we reject limits with a larger memory size than address space size
         #[test]
         fn reject_undersized_address_space() {
-        const LIMITS: Limits = Limits {
-            heap_memory_size: LIMITS_HEAP_ADDRSPACE_SIZE + 4096,
-            heap_address_space_size: LIMITS_HEAP_ADDRSPACE_SIZE,
-            stack_size: LIMITS_STACK_SIZE,
-            globals_size: LIMITS_GLOBALS_SIZE,
-        };
+            const LIMITS: Limits = Limits {
+                heap_memory_size: LIMITS_HEAP_ADDRSPACE_SIZE + 4096,
+                heap_address_space_size: LIMITS_HEAP_ADDRSPACE_SIZE,
+                stack_size: LIMITS_STACK_SIZE,
+                globals_size: LIMITS_GLOBALS_SIZE,
+            };
             let res = TestRegion::create(10, &LIMITS);
             assert!(res.is_err(), "region creation fails");
         }

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -164,6 +164,13 @@ pub trait ModuleInternal: Send + Sync {
             bail_limits_exceeded!("heap spec initial size: {:?}", heap);
         }
 
+        if heap.initial_size > heap.reserved_size {
+            return Err(lucet_incorrect_module!(
+                "initial heap size greater than reserved size: {:?}",
+                heap
+            ));
+        }
+
         if self.globals().len() * std::mem::size_of::<u64>() > limits.globals_size {
             bail_limits_exceeded!("globals exceed limits");
         }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 cast = "0.2"
 clap = "2.23"
 failure = "0.1"
+human-size = "0.4"
 libc = "0.2"
 lucet-runtime = { path = "../lucet-runtime" }
 lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals" }

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -70,12 +70,7 @@ fn main() {
                 .long("heap-address-space")
                 .takes_value(true)
                 .default_value("8 GiB")
-                .help("Maximum heap address space size (must be a multiple of 4 KiB)")
-                .long_help(
-                    "Maximum heap address space size. Must be a multiple of 4KiB, and \
-                     must be least as large as `max-heap-size`, `stack-size`, and \
-                     `globals-size`, combined.",
-                ),
+                .help("Maximum heap address space size (must be a multiple of 4 KiB, and >= `max-heap-size`)"),
         )
         .arg(
             Arg::with_name("stack_size")
@@ -130,6 +125,13 @@ fn main() {
         .unwrap_or_else(|e| e.exit())
         .into::<Byte>()
         .value() as usize;
+
+    if heap_memory_size > heap_address_space_size {
+        println!("`heap-address-space` must be at least as large as `max-heap-size`");
+        println!("{}", matches.usage());
+        std::process::exit(1);
+    }
+
     let stack_size = value_t!(matches, "stack_size", Size)
         .unwrap_or_else(|e| e.exit())
         .into::<Byte>()

--- a/lucetc/src/compiler/data.rs
+++ b/lucetc/src/compiler/data.rs
@@ -77,7 +77,7 @@ pub fn compile_sparse_page_data(compiler: &mut Compiler) -> Result<(), Error> {
     use crate::program::data::sparse::OwnedSparseData;
     let owned_data = OwnedSparseData::new(
         &compiler.prog.data_initializers()?,
-        compiler.prog.heap_spec(),
+        compiler.prog.heap_spec()?,
     );
     let sparse_data = owned_data.sparse_data();
 

--- a/lucetc/src/compiler/entity/mod.rs
+++ b/lucetc/src/compiler/entity/mod.rs
@@ -76,7 +76,7 @@ impl<'p> EntityCreator<'p> {
         compiler: &Compiler,
     ) -> Result<ir::Heap, Error> {
         let base = self.bases.heap(func, compiler);
-        let heap_spec = self.program.heap_spec();
+        let heap_spec = self.program.heap_spec()?;
 
         self.cache.heap(index, || {
             if index != 0 {

--- a/lucetc/src/compiler/memory.rs
+++ b/lucetc/src/compiler/memory.rs
@@ -5,7 +5,7 @@ use cranelift_module::{DataContext, Linkage};
 use failure::Error;
 
 pub fn compile_memory_specs(compiler: &mut Compiler) -> Result<(), Error> {
-    let heap = compiler.prog.heap_spec();
+    let heap = compiler.prog.heap_spec()?;
 
     let mut heap_spec_ctx = DataContext::new();
     heap_spec_ctx.define(serialize_spec(&heap).into_boxed_slice());

--- a/lucetc/src/compiler/module_data.rs
+++ b/lucetc/src/compiler/module_data.rs
@@ -7,10 +7,10 @@ use lucet_module_data::ModuleData;
 
 pub fn compile_module_data(compiler: &mut Compiler) -> Result<(), Error> {
     let module_data_serialized: Vec<u8> = {
-        let heap_spec = compiler.prog.heap_spec();
+        let heap_spec = compiler.prog.heap_spec()?;
         let compiled_data = OwnedSparseData::new(
             &compiler.prog.data_initializers()?,
-            compiler.prog.heap_spec(),
+            compiler.prog.heap_spec()?,
         );
         let sparse_data = compiled_data.sparse_data();
 

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -87,12 +87,20 @@ impl Lucetc {
         Ok(())
     }
 
-    pub fn reserved_size(mut self, reserved_size: u64) -> Self {
-        self.with_reserved_size(reserved_size);
+    pub fn min_reserved_size(mut self, min_reserved_size: u64) -> Self {
+        self.with_min_reserved_size(min_reserved_size);
         self
     }
-    pub fn with_reserved_size(&mut self, reserved_size: u64) {
-        self.heap.reserved_size = reserved_size;
+    pub fn with_min_reserved_size(&mut self, min_reserved_size: u64) {
+        self.heap.min_reserved_size = min_reserved_size;
+    }
+
+    pub fn max_reserved_size(mut self, max_reserved_size: u64) -> Self {
+        self.with_max_reserved_size(max_reserved_size);
+        self
+    }
+    pub fn with_max_reserved_size(&mut self, max_reserved_size: u64) {
+        self.heap.max_reserved_size = max_reserved_size;
     }
 
     pub fn guard_size(mut self, guard_size: u64) -> Self {

--- a/lucetc/src/main.rs
+++ b/lucetc/src/main.rs
@@ -50,8 +50,12 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         c.with_builtins(builtins)?;
     }
 
-    if let Some(reserved_size) = opts.reserved_size {
-        c.with_reserved_size(reserved_size);
+    if let Some(min_reserved_size) = opts.min_reserved_size {
+        c.with_min_reserved_size(min_reserved_size);
+    }
+
+    if let Some(max_reserved_size) = opts.max_reserved_size {
+        c.with_max_reserved_size(max_reserved_size);
     }
 
     if let Some(guard_size) = opts.guard_size {

--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -36,7 +36,8 @@ pub struct Options {
     pub codegen: CodegenOutput,
     pub binding_files: Vec<PathBuf>,
     pub builtins_path: Option<PathBuf>,
-    pub reserved_size: Option<u64>,
+    pub min_reserved_size: Option<u64>,
+    pub max_reserved_size: Option<u64>,
     pub guard_size: Option<u64>,
     pub opt_level: OptLevel,
 }
@@ -67,8 +68,14 @@ impl Options {
 
         let builtins_path = m.value_of("builtins").map(PathBuf::from);
 
-        let reserved_size = if let Some(reserved_str) = m.value_of("reserved_size") {
-            Some(parse_humansized(reserved_str)?)
+        let min_reserved_size = if let Some(min_reserved_str) = m.value_of("min_reserved_size") {
+            Some(parse_humansized(min_reserved_str)?)
+        } else {
+            None
+        };
+
+        let max_reserved_size = if let Some(max_reserved_str) = m.value_of("max_reserved_size") {
+            Some(parse_humansized(max_reserved_str)?)
         } else {
             None
         };
@@ -93,7 +100,8 @@ impl Options {
             codegen,
             binding_files,
             builtins_path,
-            reserved_size,
+            min_reserved_size,
+            max_reserved_size,
             guard_size,
             opt_level,
         })
@@ -128,14 +136,21 @@ impl Options {
                     .help("path to bindings json file"),
             )
             .arg(
-                Arg::with_name("reserved_size")
-                    .long("--reserved-size")
+                Arg::with_name("min_reserved_size")
+                    .long("--min-reserved-size")
                     .takes_value(true)
                     .multiple(false)
                     .help(&format!(
-                        "size of usable linear memory region. must be multiple of 4k. default: {}",
-                        humansized(HeapSettings::default().reserved_size)
+                        "minimum size of usable linear memory region. must be multiple of 4k. default: {}",
+                        humansized(HeapSettings::default().min_reserved_size)
                     )),
+            )
+            .arg(
+                Arg::with_name("max_reserved_size")
+                    .long("--max-reserved-size")
+                    .takes_value(true)
+                    .multiple(false)
+                    .help("maximum size of usable linear memory region. must be multiple of 4k. default: 4 GiB"),
             )
             .arg(
                 Arg::with_name("guard_size")

--- a/lucetc/src/program/memory.rs
+++ b/lucetc/src/program/memory.rs
@@ -1,3 +1,5 @@
+use failure::{bail, Error};
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MemorySpec {
     pub initial_pages: u32,
@@ -6,32 +8,45 @@ pub struct MemorySpec {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HeapSettings {
-    pub reserved_size: u64,
+    pub min_reserved_size: u64,
+    pub max_reserved_size: u64,
     pub guard_size: u64,
 }
 
 impl Default for HeapSettings {
     fn default() -> Self {
         Self {
-            reserved_size: 4 * 1024 * 1024,
+            min_reserved_size: 4 * 1024 * 1024,
+            max_reserved_size: 6 * 1024 * 1024 * 1024,
             guard_size: 4 * 1024 * 1024,
         }
     }
 }
 
 pub use lucet_module_data::HeapSpec;
-pub fn create_heap_spec(mem: &MemorySpec, heap: &HeapSettings) -> HeapSpec {
+pub fn create_heap_spec(mem: &MemorySpec, heap: &HeapSettings) -> Result<HeapSpec, Error> {
     let wasm_page: u64 = 64 * 1024;
 
     let initial_size = mem.initial_pages as u64 * wasm_page;
+
+    let reserved_size = std::cmp::max(initial_size, heap.min_reserved_size);
+
+    if reserved_size > heap.max_reserved_size {
+        bail!(
+            "module reserved size ({}) exceeds max reserved size ({})",
+            initial_size,
+            heap.max_reserved_size,
+        );
+    }
+
     // Find the max size permitted by the heap and the memory spec
     let max_size = mem.max_pages.map(|pages| pages as u64 * wasm_page);
-    HeapSpec {
-        reserved_size: heap.reserved_size,
+    Ok(HeapSpec {
+        reserved_size,
         guard_size: heap.guard_size,
         initial_size: initial_size,
         max_size: max_size,
-    }
+    })
 }
 pub fn empty_heap_spec() -> HeapSpec {
     HeapSpec {

--- a/lucetc/src/program/mod.rs
+++ b/lucetc/src/program/mod.rs
@@ -118,13 +118,15 @@ impl Program {
         self.runtime.get_symbol(name)
     }
 
-    pub fn heap_spec(&self) -> HeapSpec {
+    pub fn heap_spec(&self) -> Result<HeapSpec, LucetcError> {
         if let Some(ref mem_spec) = self.import_memory {
-            create_heap_spec(mem_spec, &self.heap_settings)
+            Ok(create_heap_spec(mem_spec, &self.heap_settings)
+                .context(LucetcErrorKind::MemorySpecs)?)
         } else if let Some(ref mem_spec) = self.defined_memory {
-            create_heap_spec(mem_spec, &self.heap_settings)
+            Ok(create_heap_spec(mem_spec, &self.heap_settings)
+                .context(LucetcErrorKind::MemorySpecs)?)
         } else {
-            empty_heap_spec()
+            Ok(empty_heap_spec())
         }
     }
 

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -180,7 +180,7 @@ mod programs {
         let h = HeapSettings::default();
         let p = Program::new(m, b, h).expect(&format!("instantiating program"));
         assert_eq!(
-            p.heap_spec(),
+            p.heap_spec().unwrap(),
             HeapSpec {
                 // reserved and guard is liblucet_runtime_c standard
                 reserved_size: 4 * 1024 * 1024,
@@ -201,7 +201,7 @@ mod programs {
         let h = HeapSettings::default();
         let p = Program::new(m, b, h).expect(&format!("instantiating program"));
         assert_eq!(
-            p.heap_spec(),
+            p.heap_spec().unwrap(),
             HeapSpec {
                 // reserved and guard is liblucet_runtime_c standard
                 reserved_size: 4 * 1024 * 1024,
@@ -222,7 +222,7 @@ mod programs {
         let h = HeapSettings::default();
         let p = Program::new(m, b, h).expect(&format!("instantiating program"));
         assert_eq!(
-            p.heap_spec(),
+            p.heap_spec().unwrap(),
             HeapSpec {
                 reserved_size: 0,
                 guard_size: 0,


### PR DESCRIPTION
This adds command-line parameters to `lucet-wasi` to control the memory limits, and raises the default values of those limits substantially. Most users will only ever need to turn them down, not up.

Also, this reworks the way reserved size is set in `lucetc` to provide fewer surprises; see https://github.com/fastly/lucet/pull/77/commits/b563370b6b9e1b5821f2bfe288ec956da953638f.

Finally, this switches to relying on `madvise` to zero the instance heap when an instance is reset or created, substantially improving performance for programs with large initial heaps.

Closes #74 and #76