### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto detect text and normalize to LF on commit regardless of "core.autocrlf".
+# See: https://help.github.com/en/articles/dealing-with-line-endings#example
+* text=auto eol=lf


### PR DESCRIPTION
This adds a `.gitattributes` file. This is mostly for the benefit of folks on Windows.

For reference: [rust-lang/rust/.gitattributes](https://github.com/rust-lang/rust/blob/f694222887cf31f51e68927716c25736e62f037f/.gitattributes#L3).