### PR TITLE
Build a "lucet" layer on top of "lucet-dev"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ ENV PATH=/usr/local/bin:$PATH
 RUN cargo install --root /usr/local cargo-audit cargo-watch
 
 RUN curl -sS -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-3/wasi-sdk_3.0_amd64.deb \
- && dpkg -i wasi-sdk_3.0_amd64.deb
+ && dpkg -i wasi-sdk_3.0_amd64.deb && rm -f wasi-sdk_3.0_amd64.deb
 
 ENV WASI_SDK=/opt/wasi-sdk

--- a/devenv_build_container.sh
+++ b/devenv_build_container.sh
@@ -5,12 +5,46 @@
 git submodule update --init 2>/dev/null ||:
 
 if docker image inspect lucet-dev:latest > /dev/null; then
-	if [ -z "$DEVENV_FORCE_REBUILD" ]; then
-		echo "A lucet-dev image is already present"
-		echo "Hit Ctrl-C right now if you don't want to rebuild it"
-		echo "or skip this wait by setting the DEVENV_FORCE_REBUILD variable"
-		sleep 30
-	fi
+        if [ -z "$DEVENV_FORCE_REBUILD" ]; then
+                echo "A lucet-dev image is already present"
+                echo "Hit Ctrl-C right now if you don't want to rebuild it"
+                echo "or skip this wait by setting the DEVENV_FORCE_REBUILD variable"
+                sleep 30
+        fi
 fi
 
+echo "Building lucet-dev:latest"
 docker build -t lucet-dev:latest .
+
+if [ -n "$DEVENV_NO_INSTALL" ]; then
+        docker tag lucet-dev:latest lucet:latest
+        exit
+fi
+
+if docker image inspect lucet:latest > /dev/null; then
+        if [ -z "$DEVENV_FORCE_REBUILD" ]; then
+                echo "A lucet image is already present"
+                echo "Hit Ctrl-C right now if you don't want to rebuild it"
+                echo "or skip this wait by setting the DEVENV_FORCE_REBUILD variable"
+                sleep 30
+        fi
+fi
+
+echo "Now creating lucet:latest on top of lucet-dev:latest"
+docker run --name=lucet-dev --detach --mount type=bind,src="$(cd $(dirname ${0}); pwd -P),target=/lucet" \
+        lucet-dev:latest /bin/sleep 99999999 > /dev/null
+
+echo "Building and installing optimized files in [$HOST_LUCET_MOUNT_POINT]"
+docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make install
+
+echo "Cleaning"
+docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make clean
+
+echo "Tagging the new image"
+docker container commit lucet-dev lucet:latest
+
+echo "Cleaning"
+docker kill lucet-dev
+docker rm lucet-dev
+
+echo "Done"

--- a/devenv_run.sh
+++ b/devenv_run.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
-if ! docker ps -f name=lucet | grep -Fq lucet ; then
+if ! docker ps -f name='^lucet$' | grep -Fq lucet ; then
 	${HOST_BASE_PREFIX}/devenv_start.sh
 fi
 

--- a/devenv_start.sh
+++ b/devenv_start.sh
@@ -2,21 +2,14 @@
 
 . "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
-if ! docker image inspect lucet-dev:latest > /dev/null; then
+if ! docker image inspect lucet:latest > /dev/null; then
 	${HOST_BASE_PREFIX}/devenv_build_container.sh
 fi
 
-if docker ps -f name=lucet | grep -Fq lucet ; then
+if docker ps -f name='^lucet$' | grep -Fq lucet ; then
 	echo "container is already running" >&2
 	exit 1
 fi
 
 docker run --name=lucet --detach --mount type=bind,src="$(cd $(dirname ${0}); pwd -P),target=/lucet" \
-	lucet-dev:latest /bin/sleep 99999999 > /dev/null
-
-if [ -z "$DEVENV_NO_INSTALL" ]; then
-	if ! docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet stat "$LUCET_PREFIX" > /dev/null ; then
-		echo "Lucet hasn't been installed yet... installing..."
-		docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet make install
-	fi
-fi
+	lucet:latest /bin/sleep 99999999 > /dev/null


### PR DESCRIPTION
We end up with two images.

The former being just the base development environment, suitable for CI.

The later having the release builds populated in /opt/lucet.
This is the one we can upload to the Docker Hub, as people can use it to get immediately started with Lucet without having to recompile it.

Also remove the wasi debian package after installation by the way.