### PR TITLE
Remove unexpected build flag --reserve-size

### DIFF
--- a/benchmarks/shootout/Makefile
+++ b/benchmarks/shootout/Makefile
@@ -16,7 +16,7 @@ SHOOTOUT_SRCS:=$(shell ls $(SHOOTOUT)/*.c)
 SHOOTOUT_NATIVE_OBJS:=
 SHOOTOUT_LUCET_OBJS:=
 
-LUCETC_FLAGS:=--opt-level best --reserved-size 4294967296
+LUCETC_FLAGS:=--opt-level best 
 COMMON_CFLAGS:=--std=c99 -Ofast -Wall -W -I$(SIGHTGLASS)/include
 
 SHOOTOUT_NATIVE_CFLAGS:=-march=native -fPIC \


### PR DESCRIPTION
When building using the shootout makefile in the container with:

cd /lucet
make bench

or outside with:
./devenv_run.sh make bench

an error occurs:

error: Found argument '--reserved-size' which wasn't expected, or isn't valid in this context
        Did you mean --min-reserved-size?

This patch removes the unrecognized flag.