### PR TITLE
lucet-wasi-sdk: disable threading in lld (wasm-ld)

### DIFF
--- a/lucet-wasi-sdk/src/lib.rs
+++ b/lucet-wasi-sdk/src/lib.rs
@@ -108,12 +108,14 @@ pub struct Link {
 
 impl Link {
     pub fn new<P: AsRef<Path>>(input: &[P]) -> Self {
-        Link {
+        let mut link = Link {
             input: input.iter().map(|p| PathBuf::from(p.as_ref())).collect(),
             cflags: Vec::new(),
             ldflags: Vec::new(),
             print_output: false,
-        }
+        };
+        link.with_ldflag("--no-threads");
+        link
     }
 
     pub fn cflag<S: AsRef<str>>(mut self, cflag: S) -> Self {


### PR DESCRIPTION
it appears that as of this moment both of the following are true:
* lld's wasm linker may deadlock if linking with threads enabled
* lld's wasm linker builds with threads enabled by default

some references found in tracking this down:
https://bugs.llvm.org/show_bug.cgi?id=37064

the following looks to not be wasm-related in particular:
https://bugs.llvm.org/show_bug.cgi?id=34806

but similar patterns seem to exist in the wasm driver used by lld,
even if they've since been fixed for other targets.

(this should fix travis' flaky builds since they were all due to `ld` hangs)