### PR TITLE
Compatibility with old versions of Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ env:
 services:
   - docker
 
-before_install:
-  - ./devenv_build_container.sh
-  - ./devenv_start.sh
-
 script:
   - ./devenv_run.sh make indent-check test audit
   - git diff --exit-code

--- a/devenv_run.sh
+++ b/devenv_run.sh
@@ -2,7 +2,7 @@
 
 . "$(dirname ${BASH_SOURCE:-$0})/config.inc"
 
-if ! docker ps -f name='^lucet$' | grep -Fq lucet ; then
+if ! docker ps -f name='lucet' --format '{{.Names}}' | grep -q '^lucet$' ; then
 	${HOST_BASE_PREFIX}/devenv_start.sh
 fi
 

--- a/devenv_start.sh
+++ b/devenv_start.sh
@@ -6,7 +6,7 @@ if ! docker image inspect lucet:latest > /dev/null; then
 	${HOST_BASE_PREFIX}/devenv_build_container.sh
 fi
 
-if docker ps -f name='^lucet$' | grep -Fq lucet ; then
+if docker ps -f name='lucet' --format '{{.Names}}' | grep -q '^lucet$' ; then
 	echo "container is already running" >&2
 	exit 1
 fi


### PR DESCRIPTION
Old versions of Docker, such as the one used in Travis images, didn't support regular expressions in filters.

Add a workaround for this in order to support a wider range of distributions.

Simplify Travis build rules by the way.