### PR TITLE
Replace -W,-export-dynamic with -rdynamic

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "link-args=-Wl,--export-dynamic"]
+rustflags = ["-C", "link-args=-rdynamic"]


### PR DESCRIPTION
The MacOS linker requires `-export_dynamic` instead of `-export-dynamic`.

Due to `-export-dynamic` being in the global `cargo` config, tools from Lucet that could be compiled on macOS cannot be compiled any more.

This also prevented RLS from working properly.

-rdynamic works everywhere.