### PR TITLE
Disable "cargo test" for lucet-runtime-tests

### DIFF
--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 
+[lib]
+test = false
+
 [dependencies]
 failure = "0.1"
 lazy_static = "1.1"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 
 [lib]
+# This crate only defines tests in macros, it does not contain any tests itself. This flag prevents
+# `cargo test -p lucet-runtime-tests` from trying to link an executable with undefined symbols.
 test = false
 
 [dependencies]


### PR DESCRIPTION
This crate only defines test functions for `lucet-runtime`.

As a result, it includes a (and possibly more in the future) reference to
functions in `lucet-runtime` (currently, `lucet_vmctx_get_heap`), and cannot be
built independently of `lucet-runtime`. `cargo test` will attempt to do exactly
this and result in an unhelpful build error about undefined symbols, while
trying to produce a binary to test that is tightly coupled to `lucet-runtime`
anyway.

This change disables tests for `lucet-runtime-tests` to keep cargo from trying
to build tests for this crate.

For reference, the build error mentioned above looks something like:
```
error: linking with `cc` failed: exit code: 1 
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" [long list of arguments omitted]
  = note: /lucet/target/debug/build/lucet-runtime-tests-666e0b0ed216a2ce/out/libguest_fault_traps.a(traps.o): In function `guest_func_oob': 
          /lucet/lucet-runtime/lucet-runtime-tests/src/guest_fault/traps.S:38: undefined reference to `lucet_vmctx_get_heap'
          collect2: error: ld returned 1 exit status
```