### PR TITLE
Improve portability (macOS port, part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Lucet supports running WebAssembly programs written in C (via `clang`), Rust,
 and AssemblyScript. It does not yet support the entire WebAssembly spec, but
 full support is [coming in the near future](#lucet-spectest).
 
-Lucet's runtime currently only supports x86-64 based Linux systems.
+Lucet's runtime currently only supports x86-64 based Linux systems, with
+experimental support for macOS.
 
 ## Contents
 
@@ -163,12 +164,8 @@ such as instance creation and teardown, in `/benchmarks/lucet-benchmarks`.
 
 ### Operating System
 
-Lucet is developed and tested on Linux. We expect it to work on any POSIX
-system which supports ELF.
-
-Experimentally, we have shown that supporting Mac OS (which uses the Mach-O
-executable format instead of ELF) is possible, but it is not supported at this
-time.
+Lucet is developed and tested on Linux and macOS. We expect it to work on any
+POSIX system which supports shared libraries.
 
 ### Dependencies
 

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -30,7 +30,7 @@ fn load_mkregion_and_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
         &format!("load_mkregion_and_instantiate ({})", R::TYPE_NAME),
         move |b| {
             b.iter_batched(
-                || nix::unistd::sync(),
+                || unsafe { nix::libc::sync() },
                 |_| body::<R>(&so_file),
                 criterion::BatchSize::PerIteration,
             )

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -12,6 +12,7 @@ failure = "0.1"
 lazy_static = "1.1"
 libc = "0.2.47"
 libloading = "0.5"
+memoffset = "0.2"
 nix = "0.13"
 num-derive = "0.2"
 num-traits = "0.2"
@@ -19,7 +20,6 @@ xfailure = "0.1"
 
 [dev-dependencies]
 byteorder = "1.2"
-memoffset = "0.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -5,7 +5,7 @@ use libc::{c_void, SIGSTKSZ};
 use nix::unistd::{sysconf, SysconfVar};
 use std::sync::{Arc, Once, Weak};
 
-const HOST_PAGE_SIZE_EXPECTED: usize = 4096;
+pub const HOST_PAGE_SIZE_EXPECTED: usize = 4096;
 static mut HOST_PAGE_SIZE: usize = 0;
 static HOST_PAGE_SIZE_INIT: Once = Once::new();
 

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -196,6 +196,7 @@ pub mod lucet_state {
     use crate::c_api::lucet_val;
     use crate::instance::{State, TerminationDetails};
     use crate::module::AddrDetails;
+    use crate::sysdeps::UContext;
     use crate::trapcode::{TrapCode, TrapCodeType};
     use libc::{c_char, c_void};
     use num_derive::FromPrimitive;
@@ -307,7 +308,7 @@ pub mod lucet_state {
         pub rip_addr: libc::uintptr_t,
         pub rip_addr_details: lucet_module_addr_details,
         pub signal_info: libc::siginfo_t,
-        pub context: libc::ucontext_t,
+        pub context: UContext,
     }
 
     #[repr(C)]

--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -31,9 +31,14 @@
 
 .text
 .globl lucet_context_bootstrap
+#ifdef __ELF__
 .type lucet_context_bootstrap,@function
+#else
+.globl _lucet_context_bootstrap
+#endif
 .align 16
 lucet_context_bootstrap:
+_lucet_context_bootstrap:
 	/* Move each of the context-saved registers into the corresponding call
 	 * argument register. See lucet_register enum for docs  */
 	mov %r12, %rsi
@@ -43,27 +48,44 @@ lucet_context_bootstrap:
 	mov %rbx, %r9
 	/* the next thing on the stack is the guest function - return to it */
 	ret
+#ifdef __ELF__
 .size lucet_context_bootstrap,.-lucet_context_bootstrap
-
+#endif
 
 .text
 .globl lucet_context_backstop
+#ifdef __ELF__
 .type lucet_context_backstop,@function
+#else
+.globl _lucet_context_backstop
+#endif
 .align 16
 lucet_context_backstop:
+_lucet_context_backstop:
     mov -16(%rbp), %rdi  /* parent context to arg 1 */
     mov -8(%rbp), %rsi  /* own context to arg 2 */
     mov %rax, (8*8 + 8*16 + 8*0)(%rdi) /* store return values before swapping back -- offset is offsetof(struct lucet_context, retvals) */
     mov %rdx, (8*8 + 8*16 + 8*1)(%rdi)
     movdqu %xmm0, (8*8 + 8*16 + 8*2)(%rdi) /* floating-point return value */
+#ifdef __ELF__
     jmp lucet_context_swap@PLT
+#else
+    jmp lucet_context_swap
+#endif
+#ifdef __ELF__
 .size lucet_context_backstop,.-lucet_context_backstop
+#endif
 
 .text
 .globl lucet_context_swap
+#ifdef __ELF__
 .type lucet_context_swap,@function
+#else
+.globl _lucet_context_swap
+#endif
 .align 16
 lucet_context_swap:
+_lucet_context_swap:
     // store everything in offsets from rdi (1st arg)
     mov %rbx, (0*8)(%rdi)
     mov %rsp, (1*8)(%rdi)
@@ -103,13 +125,20 @@ lucet_context_swap:
     movdqu (8*8 + 7*16)(%rsi), %xmm7
 
     ret
+#ifdef __ELF__
 .size lucet_context_swap,.-lucet_context_swap
+#endif
 
 .text
 .globl lucet_context_set
+#ifdef __ELF__
 .type lucet_context_set,@function
+#else
+.globl _lucet_context_set
+#endif
 .align 16
 lucet_context_set:
+_lucet_context_set:
     // load everything from offsets from rdi (1st arg)
     mov (0*8)(%rdi), %rbx
     mov (1*8)(%rdi), %rsp
@@ -131,7 +160,11 @@ lucet_context_set:
     // load rdi from itself last
     mov (3*8)(%rdi), %rdi
     ret
+#ifdef __ELF__
 .size lucet_context_set,.-lucet_context_set
+#endif
 
 /* Mark that we don't need executable stack. */
+#if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
+#endif

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -9,6 +9,7 @@ use crate::embed_ctx::CtxMap;
 use crate::error::Error;
 use crate::instance::siginfo_ext::SiginfoExt;
 use crate::module::{self, Global, Module};
+use crate::sysdeps::UContext;
 use crate::trapcode::{TrapCode, TrapCodeType};
 use crate::val::{UntypedRetVal, Val};
 use crate::WASM_PAGE_SIZE;
@@ -623,7 +624,7 @@ pub enum State {
     Fault {
         details: FaultDetails,
         siginfo: libc::siginfo_t,
-        context: libc::ucontext_t,
+        context: UContext,
     },
     Terminated {
         details: TerminationDetails,

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -27,7 +27,7 @@ pub const LUCET_INSTANCE_MAGIC: u64 = 746932922;
 #[cfg(target_os = "linux")]
 pub const INSTANCE_PADDING: usize = 2328;
 #[cfg(target_os = "macos")]
-pub const INSTANCE_PADDING: usize = 2648;
+pub const INSTANCE_PADDING: usize = 2642;
 
 thread_local! {
     /// The host context.

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -194,6 +194,9 @@ pub struct Instance {
     /// Pointer to the function used as the entrypoint (for use in backtraces)
     entrypoint: *const extern "C" fn(),
 
+    /// `_padding` must be the last member of the structure.
+    /// This marks where the padding starts to make the structure exactly 4096 bytes long.
+    /// It is also used to compute the size of the structure up to that point, i.e. without padding.
     _padding: (),
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -53,7 +53,8 @@ impl Instance {
             SigStackFlags::empty(),
             libc::SIGSTKSZ,
         );
-        let saved_sigstack = unsafe { sigaltstack(&guest_sigstack).expect("sigaltstack succeeds") };
+        let saved_sigstack =
+            unsafe { sigaltstack(&guest_sigstack).expect("saving sigaltstack succeeds") };
 
         let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
         if let Some(ref mut state) = *ostate {
@@ -74,7 +75,7 @@ impl Instance {
             if state.counter == 0 {
                 unsafe {
                     // restore the host signal stack
-                    sigaltstack(&saved_sigstack).expect("sigaltstack succeeds");
+                    sigaltstack(&saved_sigstack).expect("sigaltstack restoration succeeds");
                     restore_host_signal_state(state);
                 }
                 true

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -2,6 +2,7 @@ use crate::context::Context;
 use crate::instance::{
     FaultDetails, Instance, State, TerminationDetails, CURRENT_INSTANCE, HOST_CTX,
 };
+use crate::sysdeps::UContextPtr;
 use crate::trapcode::{TrapCode, TrapCodeType};
 use failure::Error;
 use lazy_static::lazy_static;
@@ -109,12 +110,9 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
 
     // Safety: when using a SA_SIGINFO sigaction, the third argument can be cast to a `ucontext_t`
     // pointer per the manpage
-    let ctx = unsafe {
-        (ucontext_ptr as *mut libc::ucontext_t)
-            .as_ref()
-            .expect("ucontext must not be null")
-    };
-    let rip = ctx.uc_mcontext.gregs[libc::REG_RIP as usize] as *const c_void;
+    assert!(!ucontext_ptr.is_null());
+    let ctx = UContextPtr::new(ucontext_ptr);
+    let rip = ctx.get_ip();
 
     let switch_to_host = CURRENT_INSTANCE.with(|current_instance| {
         let mut current_instance = current_instance.borrow_mut();
@@ -178,7 +176,7 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
                     // safety: pointer is checked for null at the top of the function, and the
                     // manpage guarantees that a siginfo_t will be passed as the second argument
                     siginfo: unsafe { *siginfo_ptr },
-                    context: *ctx,
+                    context: ctx.into(),
                 };
                 true
             }

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -111,7 +111,7 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
 
     // Safety: when using a SA_SIGINFO sigaction, the third argument can be cast to a `ucontext_t`
     // pointer per the manpage
-    assert!(!ucontext_ptr.is_null());
+    assert!(!ucontext_ptr.is_null(), "ucontext_ptr must not be null");
     let ctx = UContextPtr::new(ucontext_ptr);
     let rip = ctx.get_ip();
 

--- a/lucet-runtime/lucet-runtime-internals/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/lib.rs
@@ -18,6 +18,7 @@ pub mod embed_ctx;
 pub mod instance;
 pub mod module;
 pub mod region;
+pub mod sysdeps;
 pub mod trapcode;
 pub mod val;
 pub mod vmctx;

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -236,7 +236,7 @@ impl MmapRegion {
                 ptr::null_mut(),
                 region.limits.total_memory_size(),
                 ProtFlags::PROT_NONE,
-                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
+                MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
                 0,
                 0,
             )?

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/linux.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/linux.rs
@@ -1,0 +1,52 @@
+use libc::{c_void, ucontext_t, REG_RIP};
+
+#[derive(Clone, Copy, Debug)]
+pub struct UContextPtr(*const ucontext_t);
+
+impl UContextPtr {
+    #[inline]
+    pub fn new(ptr: *const c_void) -> Self {
+        assert!(!ptr.is_null(), "non-null context");
+        UContextPtr(ptr as *const ucontext_t)
+    }
+
+    #[inline]
+    pub fn get_ip(&self) -> *const c_void {
+        let mcontext = &unsafe { *(self.0) }.uc_mcontext;
+        mcontext.gregs[REG_RIP as usize] as *const _
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct UContext {
+    context: ucontext_t,
+}
+
+impl UContext {
+    #[inline]
+    pub fn new(ptr: *const c_void) -> Self {
+        UContext {
+            context: *unsafe {
+                (ptr as *const ucontext_t)
+                    .as_ref()
+                    .expect("non-null context")
+            },
+        }
+    }
+}
+
+impl Into<UContext> for UContextPtr {
+    #[inline]
+    fn into(self) -> UContext {
+        UContext {
+            context: unsafe { *(self.0) },
+        }
+    }
+}
+
+impl Into<UContextPtr> for UContext {
+    #[inline]
+    fn into(self) -> UContextPtr {
+        UContextPtr::new(&self.context as *const _ as *const _)
+    }
+}

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/linux.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/linux.rs
@@ -11,7 +11,7 @@ impl UContextPtr {
     }
 
     #[inline]
-    pub fn get_ip(&self) -> *const c_void {
+    pub fn get_ip(self) -> *const c_void {
         let mcontext = &unsafe { *(self.0) }.uc_mcontext;
         mcontext.gregs[REG_RIP as usize] as *const _
     }
@@ -33,6 +33,10 @@ impl UContext {
             },
         }
     }
+
+    pub fn as_ptr(&mut self) -> UContextPtr {
+        UContextPtr::new(&self.context as *const _ as *const _)
+    }
 }
 
 impl Into<UContext> for UContextPtr {
@@ -41,12 +45,5 @@ impl Into<UContext> for UContextPtr {
         UContext {
             context: unsafe { *(self.0) },
         }
-    }
-}
-
-impl Into<UContextPtr> for UContext {
-    #[inline]
-    fn into(self) -> UContextPtr {
-        UContextPtr::new(&self.context as *const _ as *const _)
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/macos.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/macos.rs
@@ -1,0 +1,174 @@
+use libc::{c_int, c_short, c_void, sigset_t, size_t};
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct sigaltstack {
+    pub ss_sp: *const c_void,
+    pub ss_size: size_t,
+    pub ss_flags: c_int,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct x86_exception_state64 {
+    pub trapno: u16,
+    pub cpu: u16,
+    pub err: u32,
+    pub faultvaddr: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct x86_thread_state64 {
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rdi: u64,
+    pub rsi: u64,
+    pub rbp: u64,
+    pub rsp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    pub rip: u64,
+    pub rflags: u64,
+    pub cs: u64,
+    pub fs: u64,
+    pub gs: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct mmst_reg {
+    pub mmst_reg: [u8; 10],
+    pub rsrv: [u8; 6],
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct xmm_reg([u8; 16]);
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct x86_float_state64 {
+    pub fpu_reserved: [c_int; 2],
+    pub fpu_fcw: c_short,
+    pub fpu_fsw: c_short,
+    pub fpu_ftw: u8,
+    pub fpu_rsrv1: u8,
+    pub fpu_fop: u16,
+    pub fpu_ip: u32,
+    pub fpu_cs: u16,
+    pub fpu_rsrv2: u16,
+    pub fpu_dp: u32,
+    pub fpu_ds: u16,
+    pub fpu_rsrv3: u16,
+    pub fpu_mxcsr: u32,
+    pub fpu_mxcsrmask: u32,
+    pub fpu_stmm0: mmst_reg,
+    pub fpu_stmm1: mmst_reg,
+    pub fpu_stmm2: mmst_reg,
+    pub fpu_stmm3: mmst_reg,
+    pub fpu_stmm4: mmst_reg,
+    pub fpu_stmm5: mmst_reg,
+    pub fpu_stmm6: mmst_reg,
+    pub fpu_stmm7: mmst_reg,
+    pub fpu_xmm0: xmm_reg,
+    pub fpu_xmm1: xmm_reg,
+    pub fpu_xmm2: xmm_reg,
+    pub fpu_xmm3: xmm_reg,
+    pub fpu_xmm4: xmm_reg,
+    pub fpu_xmm5: xmm_reg,
+    pub fpu_xmm6: xmm_reg,
+    pub fpu_xmm7: xmm_reg,
+    pub fpu_xmm8: xmm_reg,
+    pub fpu_xmm9: xmm_reg,
+    pub fpu_xmm10: xmm_reg,
+    pub fpu_xmm11: xmm_reg,
+    pub fpu_xmm12: xmm_reg,
+    pub fpu_xmm13: xmm_reg,
+    pub fpu_xmm14: xmm_reg,
+    pub fpu_xmm15: xmm_reg,
+    pub fpu_rsrv4_0: [u8; 16],
+    pub fpu_rsrv4_1: [u8; 16],
+    pub fpu_rsrv4_2: [u8; 16],
+    pub fpu_rsrv4_3: [u8; 16],
+    pub fpu_rsrv4_4: [u8; 16],
+    pub fpu_rsrv4_5: [u8; 16],
+    pub fpu_reserved1: c_int,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct mcontext64 {
+    pub es: x86_exception_state64,
+    pub ss: x86_thread_state64,
+    pub fs: x86_float_state64,
+}
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct ucontext_t {
+    pub uc_onstack: c_int,
+    pub uc_sigmask: sigset_t,
+    pub uc_stack: sigaltstack,
+    pub uc_link: *const ucontext_t,
+    pub uc_mcsize: size_t,
+    pub uc_mcontext: *const mcontext64,
+    mcontext_data: mcontext64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UContextPtr(*const ucontext_t);
+
+impl UContextPtr {
+    #[inline]
+    pub fn new(ptr: *const c_void) -> Self {
+        assert!(!ptr.is_null(), "non-null context");
+        UContextPtr(ptr as *const ucontext_t)
+    }
+
+    #[inline]
+    pub fn get_ip(&self) -> *const c_void {
+        let mcontext = &unsafe { *(self.0) }.mcontext_data;
+        mcontext.ss.rip as *const _
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct UContext {
+    context: ucontext_t,
+}
+
+impl UContext {
+    #[inline]
+    pub fn new(ptr: *const c_void) -> Self {
+        UContext {
+            context: *unsafe {
+                (ptr as *const ucontext_t)
+                    .as_ref()
+                    .expect("non-null context")
+            },
+        }
+    }
+}
+
+impl Into<UContext> for UContextPtr {
+    #[inline]
+    fn into(self) -> UContext {
+        UContext {
+            context: unsafe { *(self.0) },
+        }
+    }
+}
+
+impl Into<UContextPtr> for UContext {
+    #[inline]
+    fn into(self) -> UContextPtr {
+        UContextPtr::new(&self.context as *const _ as *const _)
+    }
+}

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "macos")]
+pub use macos::*;
+
+#[cfg(target_os = "linux")]
+pub use linux::*;

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -143,7 +143,7 @@ macro_rules! guest_fault_tests {
                 ptr::null_mut(),
                 4096,
                 ProtFlags::PROT_NONE,
-                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE,
+                MapFlags::MAP_ANON | MapFlags::MAP_PRIVATE,
                 0,
                 0,
             )

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault/traps.S
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault/traps.S
@@ -1,8 +1,13 @@
 	.text
 	.globl	guest_func_illegal_instr # -- Begin function guest_func_illegal_instr
+#ifdef __ELF__
+	.type   guest_func_illegal_instr,@function
+#else
+	.globl	_guest_func_illegal_instr
+#endif
 	.p2align	4, 0x90
-	.type	guest_func_illegal_instr,@function
 guest_func_illegal_instr:               # @guest_func_illegal_instr
+_guest_func_illegal_instr:
 	.cfi_startproc
 # %bb.0:
 	pushq	%rbp
@@ -18,13 +23,20 @@ guest_func_illegal_instr:               # @guest_func_illegal_instr
 	.cfi_def_cfa %rsp, 8
 	retq
 .Lfunc_end0:
-	.size	guest_func_illegal_instr, .Lfunc_end0-guest_func_illegal_instr
+#ifdef ___ELF__
+	.size   guest_func_illegal_instr, .Lfunc_end0-guest_func_illegal_instr
+#endif
 	.cfi_endproc
                                         # -- End function
 	.globl	guest_func_oob          # -- Begin function guest_func_oob
-	.p2align	4, 0x90
+#ifdef __ELF__
 	.type	guest_func_oob,@function
+#else
+	.globl	_guest_func_oob
+#endif
+	.p2align	4, 0x90
 guest_func_oob:                         # @guest_func_oob
+_guest_func_oob:
 	.cfi_startproc
 # %bb.0:
 	pushq	%rbp
@@ -35,7 +47,11 @@ guest_func_oob:                         # @guest_func_oob
 	subq	$16, %rsp
 	movq	%rdi, -8(%rbp)
 	movq	-8(%rbp), %rdi
+#ifdef __ELF__
 	callq	lucet_vmctx_get_heap@PLT
+#else
+	callq	_lucet_vmctx_get_heap
+#endif
 	movq	%rax, -16(%rbp)
 	movq	-16(%rbp), %rax
 	movb	$0, 65537(%rax)
@@ -44,8 +60,11 @@ guest_func_oob:                         # @guest_func_oob
 	.cfi_def_cfa %rsp, 8
 	retq
 .Lfunc_end1:
-	.size	guest_func_oob, .Lfunc_end1-guest_func_oob
+#ifdef __ELF__
+	.size   guest_func_oob, .Lfunc_end1-guest_func_oob
+#endif
 	.cfi_endproc
-                                        # -- End function
-	.ident	"clang version 7.0.1-svn348686-1~exp1~20181221231927.53 (branches/release_70)"
+
+#if defined(__linux__) && defined(__ELF__)
 	.section	".note.GNU-stack","",@progbits
+#endif

--- a/lucet-wasi/build.rs
+++ b/lucet-wasi/build.rs
@@ -6,14 +6,34 @@ use std::process::{Command, Stdio};
 fn main() {
     let wasi_sdk =
         Path::new(&env::var("WASI_SDK").unwrap_or("/opt/wasi-sdk".to_owned())).to_path_buf();
+    let wasi_sysroot = match env::var("WASI_SYSROOT") {
+        Ok(wasi_sysroot) => Path::new(&wasi_sysroot).to_path_buf(),
+        Err(_) => wasi_sdk.join("share/sysroot"),
+    };
+    let clang_root = match env::var("CLANG_ROOT") {
+        Ok(clang_root) => Path::new(&clang_root).to_path_buf(),
+        Err(_) => wasi_sdk.join("lib/clang/8.0.0"),
+    };
+    assert!(
+        wasi_sysroot.exists(),
+        "wasi-sysroot not present at {:?}",
+        wasi_sysroot
+    );
+    assert!(
+        clang_root.exists(),
+        "clang-root not present at {:?}",
+        clang_root
+    );
 
-    assert!(wasi_sdk.exists(), "wasi-sdk not present at {:?}", wasi_sdk);
+    let wasi_sysroot_core_h = wasi_sysroot.join("include/wasi/core.h");
 
-    let wasi_sdk_core_h = wasi_sdk.join("share/sysroot/include/wasi/core.h");
+    assert!(
+        wasi_sysroot_core_h.exists(),
+        "wasi-sysroot core.h not present at {:?}",
+        wasi_sysroot_core_h
+    );
 
-    assert!(wasi_sdk_core_h.exists(), "wasi-sdk core.h not present at {:?}", wasi_sdk_core_h);
-
-    println!("cargo:rerun-if-changed={}", wasi_sdk_core_h.display());
+    println!("cargo:rerun-if-changed={}", wasi_sysroot_core_h.display());
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
@@ -25,7 +45,7 @@ fn main() {
     let sed_result = Command::new("sed")
         .arg("-E")
         .arg(r#"s/U?INT[0-9]+_C\(((0x)?[0-9]+)\)/\1/g"#)
-        .arg(wasi_sdk_core_h)
+        .arg(wasi_sysroot_core_h)
         .stdout(Stdio::from(core_h))
         .status()
         .expect("can execute sed");
@@ -34,18 +54,15 @@ fn main() {
         // something failed, but how?
         match sed_result.code() {
             Some(code) => panic!("sed failed with code {}", code),
-            None       => panic!("sed exited abnormally")
+            None => panic!("sed exited abnormally"),
         }
     }
 
     let host_builder = bindgen::Builder::default()
         .clang_arg("-nostdinc")
         .clang_arg("-D__wasi__")
-        .clang_arg(format!(
-            "-isystem={}/share/sysroot/include/",
-            wasi_sdk.display()
-        ))
-        .clang_arg(format!("-I{}/lib/clang/8.0.0/include/", wasi_sdk.display()))
+        .clang_arg(format!("-isystem={}/include/", wasi_sysroot.display()))
+        .clang_arg(format!("-I{}/include/", clang_root.display()))
         .header(core_h_path.to_str().unwrap())
         .whitelist_type("__wasi_.*")
         .whitelist_var("__WASI_.*");

--- a/lucet-wasi/src/host.rs
+++ b/lucet-wasi/src/host.rs
@@ -98,6 +98,12 @@ pub fn errno_from_nix(errno: nix::errno::Errno) -> __wasi_errno_t {
     e as __wasi_errno_t
 }
 
+#[cfg(target_os = "linux")]
+const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
+
+#[cfg(not(target_os = "linux"))]
+const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_SYNC;
+
 pub fn nix_from_fdflags(fdflags: __wasi_fdflags_t) -> nix::fcntl::OFlag {
     use nix::fcntl::OFlag;
     let mut nix_flags = OFlag::empty();
@@ -111,7 +117,7 @@ pub fn nix_from_fdflags(fdflags: __wasi_fdflags_t) -> nix::fcntl::OFlag {
         nix_flags.insert(OFlag::O_NONBLOCK);
     }
     if fdflags & (__WASI_FDFLAG_RSYNC as __wasi_fdflags_t) != 0 {
-        nix_flags.insert(OFlag::O_RSYNC);
+        nix_flags.insert(O_RSYNC);
     }
     if fdflags & (__WASI_FDFLAG_SYNC as __wasi_fdflags_t) != 0 {
         nix_flags.insert(OFlag::O_SYNC);
@@ -131,7 +137,7 @@ pub fn fdflags_from_nix(oflags: nix::fcntl::OFlag) -> __wasi_fdflags_t {
     if oflags.contains(OFlag::O_NONBLOCK) {
         fdflags |= __WASI_FDFLAG_NONBLOCK;
     }
-    if oflags.contains(OFlag::O_RSYNC) {
+    if oflags.contains(O_RSYNC) {
         fdflags |= __WASI_FDFLAG_RSYNC;
     }
     if oflags.contains(OFlag::O_SYNC) {

--- a/lucet-wasi/src/hostcalls.rs
+++ b/lucet-wasi/src/hostcalls.rs
@@ -24,6 +24,12 @@ use std::os::unix::prelude::{FromRawFd, OsStrExt, OsStringExt, RawFd};
 use std::time::SystemTime;
 use std::{cmp, slice};
 
+#[cfg(target_os = "linux")]
+const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_RSYNC;
+
+#[cfg(not(target_os = "linux"))]
+const O_RSYNC: nix::fcntl::OFlag = nix::fcntl::OFlag::O_SYNC;
+
 #[no_mangle]
 pub extern "C" fn __wasi_proc_exit(vmctx: *mut lucet_vmctx, rval: wasm32::__wasi_exitcode_t) -> ! {
     let mut vmctx = unsafe { Vmctx::from_raw(vmctx) };
@@ -618,7 +624,7 @@ pub extern "C" fn __wasi_path_open(
     if nix_all_oflags.contains(OFlag::O_DSYNC) {
         needed_inheriting |= host::__WASI_RIGHT_FD_DATASYNC as host::__wasi_rights_t;
     }
-    if nix_all_oflags.intersects(OFlag::O_RSYNC | OFlag::O_SYNC) {
+    if nix_all_oflags.intersects(O_RSYNC | OFlag::O_SYNC) {
         needed_inheriting |= host::__WASI_RIGHT_FD_SYNC as host::__wasi_rights_t;
     }
 


### PR DESCRIPTION
This improves portability of the toolchain to non-Linux systems, and adds preliminary support for running Lucet natively on macOS.

* Make `ucontext` a Rust structure instead of using the Linux-specific structure directly. `nix` and `libc` don't have a definition for `ucontext_t` and its dependencies on macOS yet, so we have to provide it for now. I'll send a PR to these in order to have this merged upstream.
* Make assembly code compatible with non-ELF (namely, Mach-O) systems.
* Don't require `wasi-sdk` to be present. `clang` and the wasi sysroot can have different roots (defined in `CLANG_ROOT` and `WASI_SYSROOT`). They are still derived from the `wasi-sdk` path by default. So that the system-provided LLVM installation can be used directly on macOS and Linux distributions with up-to-date packages.
* `O_RSYNC` is Linux-specific.
* Adjust `Instance` padding for the macOS context size.

Documentation on how to compile and use Lucet on macOS, and more generally without `wasi-sdk` is still lacking, but this can be addressed in a dedicated PR.