### PR TITLE
Fix setenv script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ lucet-wasi hello.so
 * `./devenv_run.sh [<command>] [<arg>...]` runs a command in the container. If
   a command is not provided, an interactive shell is spawned. In this
   container, Lucet tools are installed in `/opt/lucet` by default. The command
-  `source /opt/lucet/bin/lucet_setenv.sh` can be used to initialize the
+  `source /opt/lucet/bin/devenv_setenv.sh` can be used to initialize the
   environment.
 * `./devenv_start.sh` and `./devenv_stop.sh` start and stop the container.
 


### PR DESCRIPTION
In [this PR](https://github.com/fastly/lucet/pull/49), `lucet_setenv` was moved to `devenv_setenv`. So now you will see this error.
```
# source /opt/lucet/bin/lucet_setenv.sh
bash: /opt/lucet/bin/lucet_setenv.sh: No such file or directory
```