### PR TITLE
gitattributes: note that png and jpg are binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Auto detect text and normalize to LF on commit regardless of "core.autocrlf".
 # See: https://help.github.com/en/articles/dealing-with-line-endings#example
 * text=auto eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+*.wasm binary


### PR DESCRIPTION
the assets/*.png files were getting CRLF'd up during rebases