### PR TITLE
Check that INSTANCE_PADDING is correct

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -3,7 +3,7 @@ pub mod signals;
 
 pub use crate::instance::signals::{signal_handler_none, SignalBehavior, SignalHandler};
 
-use crate::alloc::Alloc;
+use crate::alloc::{host_page_size, Alloc};
 use crate::context::Context;
 use crate::embed_ctx::CtxMap;
 use crate::error::Error;
@@ -22,7 +22,11 @@ use std::ptr::{self, NonNull};
 use std::sync::Arc;
 
 pub const LUCET_INSTANCE_MAGIC: u64 = 746932922;
+
+#[cfg(target_os = "linux")]
 pub const INSTANCE_PADDING: usize = 2328;
+#[cfg(target_os = "macos")]
+pub const INSTANCE_PADDING: usize = 2648;
 
 thread_local! {
     /// The host context.
@@ -457,7 +461,7 @@ impl Instance {
 impl Instance {
     fn new(alloc: Alloc, module: Arc<dyn Module>, embed_ctx: CtxMap) -> Self {
         let globals_ptr = alloc.slot().globals as *mut i64;
-        Instance {
+        let inst = Instance {
             magic: LUCET_INSTANCE_MAGIC,
             embed_ctx: embed_ctx,
             module,
@@ -472,7 +476,19 @@ impl Instance {
             entrypoint: ptr::null(),
             _reserved: [0; INSTANCE_PADDING],
             globals_ptr,
-        }
+        };
+
+        // Verify that globals_ptr is right before the end of a page, and that
+        // it is the last member of the structure.
+        let globals_ptr_offset =
+            &inst.globals_ptr as *const _ as usize - &inst as *const _ as usize;
+        let page_size = host_page_size();
+        assert_eq!(
+            globals_ptr_offset + std::mem::size_of_val(&inst.globals_ptr),
+            page_size
+        );
+        assert_eq!(std::mem::size_of_val(&inst), page_size);
+        inst
     }
 
     /// Run a function in guest context at the given entrypoint.


### PR DESCRIPTION
This hard-coded padding size has been the cause of headaches in the original C version, because it may need to be adjusted every time a change is made to the `Instance` structure.

Furthermore, the context is platform-dependent, so the padding cannot be one-size-fits-all.

The globals pointer must be right at the end of the page, and the last member of the structure. This is documented, but not enforced in code.

Reintroduce the checks making sure that this is the case.

The `INSTANCE_PADDING` constant remains fragile, and we can probably find a better way to handle this. Even on Linux, I'm not convinced that the current value is correct on non-x86_64 architectures.

The check can save quite a bit of debugging time when it's off.

Also add the current value for macOS.

We probably don't want a catchall value, as it is likely to be wrong on untested platforms.