### PR TITLE
Build a complete function manifest

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -19,7 +19,7 @@ use cranelift_module::{Backend as ClifBackend, Module as ClifModule};
 use cranelift_native;
 use cranelift_wasm::{translate_module, FuncTranslator, WasmError};
 use failure::{format_err, Fail, ResultExt};
-use lucet_module_data::ModuleData;
+use lucet_module_data::{FunctionSpec, ModuleData};
 
 #[derive(Debug, Clone, Copy)]
 pub enum OptLevel {
@@ -136,7 +136,21 @@ impl<'a> Compiler<'a> {
         write_startfunc_data(&mut self.clif_module, &self.decls)?;
         write_table_data(&mut self.clif_module, &self.decls)?;
 
-        let obj = ObjectFile::new(self.clif_module.finish()).context(LucetcErrorKind::Output)?;
+        let function_manifest: Vec<(String, FunctionSpec)> = self
+            .clif_module
+            .declared_functions()
+            .filter_map(|f| {
+                f.compiled.as_ref().map(|compiled| {
+                    (
+                        f.decl.name.to_owned(), // this copy is only necessary because `clif_module` is moved in `finish, below`
+                        FunctionSpec::new(0, compiled.code_length(), 0, 0),
+                    )
+                })
+            })
+            .collect();
+
+        let obj = ObjectFile::new(self.clif_module.finish(), function_manifest)
+            .context(LucetcErrorKind::Output)?;
         Ok(obj)
     }
 

--- a/lucetc/src/function_manifest.rs
+++ b/lucetc/src/function_manifest.rs
@@ -29,18 +29,8 @@ fn write_relocated_slice(
 ///
 /// Writes a manifest of functions, with relocations, to the artifact.
 ///
-/// THIS IS NOT CURRENTLY A COMPLETE LIST OF FUNCTIONS.
-///
-/// Currently the manifest returned here is the subset of functions
-/// that happen to have traps. This manifest is only used, right now,
-/// to look up trap manifest mappings, so this all lines up.
-///
-/// The *order* of these functions are not (currently) guaranteed either!
-/// Just that at the moment this order happens to be the same order as
-/// `FaerieTrapManifest` lists.
-///
 pub fn write_function_manifest(
-    functions: &[(&str, FunctionSpec)],
+    functions: &[(String, FunctionSpec)],
     obj: &mut Artifact,
 ) -> Result<(), Error> {
     let manifest_len_sym = "lucet_function_manifest_len";

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -19,7 +19,7 @@ use failure::Error;
 pub const STACK_PROBE_SYM: &'static str = "lucet_probestack";
 
 /// The binary of the stack probe.
-pub const STACK_PROBE_BINARY: &'static [u8] = &[
+pub(crate) const STACK_PROBE_BINARY: &'static [u8] = &[
     // 49 89 c3                     mov    %rax,%r11
     // 48 81 ec 00 10 00 00         sub    $0x1000,%rsp
     // 48 85 64 24 08               test   %rsp,0x8(%rsp)


### PR DESCRIPTION
This provides a complete list of functions in the artifact, rather than what we were using - the subset that happened to possibly trap.

~(CI will fail because this depends on a cranelift change)~ the change was merged!