### PR TITLE
Replace hard-coded link flags with portable link options

### DIFF
--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -1,5 +1,10 @@
 #! /bin/sh
 
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Installation on this operating system cannot be done using that script yet." >&2
+    exit 1
+fi
+
 LUCET_SRC_PREFIX=${LUCET_SRC_PREFIX:-"$(readlink -e $(dirname $(dirname ${0})))"}
 if [ ! -x "${LUCET_SRC_PREFIX}/helpers/install.sh" ]; then
     echo "Unable to find the current script base directory" >&2

--- a/lucet-builtins/Makefile
+++ b/lucet-builtins/Makefile
@@ -17,6 +17,7 @@ build/%.o: src/%.c
 	$(CC) $(COMMON_CFLAGS) -c $^ -o $@
 
 build/libbuiltins.so: $(LIBBUILTINS_OBJS)
+	$(CC) -Wl,-U,_lucet_vmctx_current_memory -Wl,-U,_lucet_vmctx_get_heap -shared $^ -o $@ 2> /dev/null || \
 	$(CC) -shared $^ -o $@
 
 .PHONY: clean

--- a/lucet-builtins/Makefile
+++ b/lucet-builtins/Makefile
@@ -17,6 +17,7 @@ build/%.o: src/%.c
 	$(CC) $(COMMON_CFLAGS) -c $^ -o $@
 
 build/libbuiltins.so: $(LIBBUILTINS_OBJS)
+	# -U is not supported by the GNU linker. Retry without this option if the first command fails.
 	$(CC) -Wl,-U,_lucet_vmctx_current_memory -Wl,-U,_lucet_vmctx_get_heap -shared $^ -o $@ 2> /dev/null || \
 	$(CC) -shared $^ -o $@
 

--- a/lucet-runtime/include/lucet.h
+++ b/lucet-runtime/include/lucet.h
@@ -6,7 +6,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <ucontext.h>
 
 #include "lucet_types.h"
 #include "lucet_val.h"

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -1,10 +1,15 @@
 #ifndef LUCET_TYPES_H
 #define LUCET_TYPES_H
 
+#ifndef _XOPEN_SOURCE
+# define _XOPEN_SOURCE 500
+#endif
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <ucontext.h>
 
 enum lucet_error {
     lucet_error_ok,

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -9,7 +9,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <ucontext.h>
+
+#ifdef __APPLE__
+# include <sys/ucontext.h>
+#else
+# include <ucontext.h>
+#endif
 
 enum lucet_error {
     lucet_error_ok,

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/macos.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/macos.rs
@@ -139,6 +139,7 @@ impl UContextPtr {
 }
 
 #[derive(Clone, Copy)]
+#[repr(C)]
 pub struct UContext {
     context: ucontext_t,
     mcontext: mcontext64,

--- a/lucet-runtime/lucet-runtime-tests/src/build.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/build.rs
@@ -1,6 +1,6 @@
 use failure::Error;
 use lucet_runtime_internals::module::DlModule;
-use lucet_wasi_sdk::{CompileOpts, Link, LinkOpts};
+use lucet_wasi_sdk::{CompileOpts, Link, LinkOpt, LinkOpts};
 use lucetc::{Bindings, Lucetc, LucetcOpts};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -31,9 +31,9 @@ where
 
     let wasm_build = Link::new(&[c_file])
         .with_cflag("-nostartfiles")
-        .with_ldflag("--no-entry")
-        .with_ldflag("--allow-undefined")
-        .with_ldflag("--export-all");
+        .with_link_opt(LinkOpt::NoDefaultEntryPoint)
+        .with_link_opt(LinkOpt::AllowUndefinedAll)
+        .with_link_opt(LinkOpt::ExportAll);
 
     let wasm_file = workdir.path().join("out.wasm");
 

--- a/lucetc/tests/wasi-sdk.rs
+++ b/lucetc/tests/wasi-sdk.rs
@@ -1,5 +1,5 @@
 use failure::{Error, ResultExt};
-use lucet_wasi_sdk::{CompileOpts, Link, LinkOpts};
+use lucet_wasi_sdk::{CompileOpts, Link, LinkOpt, LinkOpts};
 use lucetc::bindings::Bindings;
 use lucetc::load;
 use parity_wasm::elements::Module;
@@ -23,10 +23,10 @@ fn module_from_c(cfiles: &[&str], exports: &[&str]) -> Result<Module, Error> {
 
     let mut linker = Link::new(&cfiles)
         .with_cflag("-nostartfiles")
-        .with_ldflag("--no-entry")
-        .with_ldflag("--allow-undefined");
+        .with_link_opt(LinkOpt::NoDefaultEntryPoint)
+        .with_link_opt(LinkOpt::AllowUndefinedAll);
     for export in exports {
-        linker.ldflag(&format!("--export={}", export));
+        linker.export(export);
     }
     linker.link(wasm.clone())?;
 


### PR DESCRIPTION
Instead of hard-coded, linker-specific command-line flags, define a portable set of options to express the intent.

These options are then converted into the correct set of command-line flags for the given linker.

We may eventually want to do the same thing for the compiler, but this is not really necessary for now since clang is all we support.

Also make `ucontext` inclusion more portable to non-glibc environments.