### PR TITLE
gitignore: core.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 *.rs.bk
 *.pyc
 host
+core.*
 
 # csmith-generated
 /platform.info


### PR DESCRIPTION
some rude CI system we use puts cores into $PWD, and the lucet-runtime test suite forks two processes that are intended to abort. this gitignore makes the presence of those files not flag the git diff as dirty.