### PR TITLE
lucet-wasi header fixups

### DIFF
--- a/lucet-wasi/include/lucet_wasi.h
+++ b/lucet-wasi/include/lucet_wasi.h
@@ -5,7 +5,7 @@
 
 struct lucet_wasi_ctx;
 
-struct lucet_wasi_ctx *lucet_wasi_ctx_create();
+struct lucet_wasi_ctx *lucet_wasi_ctx_create(void);
 
 enum lucet_error lucet_wasi_ctx_args(struct lucet_wasi_ctx *wasi_ctx, size_t argc, char **argv);
 

--- a/lucet-wasi/tests/guests/getrusage.c
+++ b/lucet-wasi/tests/guests/getrusage.c
@@ -1,6 +1,11 @@
 #include <assert.h>
 #include <sys/resource.h>
 
+// Temporary fix until
+// https://github.com/CraneStation/wasi-sysroot/pull/24/
+// is available in wasi-sdk package
+extern int getrusage(int who, struct rusage *usage);
+
 int main()
 {
     struct rusage ru1;


### PR DESCRIPTION
* fix the lucet-wasi C API header warning thrown with strict prototypes
* fix test that uses getrusage, prototype temporarily unavailable due to wasi-sysroot bug fixed upstream. only effects using wasi-sdk release 4