### PR TITLE
Short reads from readv(2) don't mean EOF

### DIFF
--- a/lucet-wasi/src/hostcalls.rs
+++ b/lucet-wasi/src/hostcalls.rs
@@ -499,14 +499,12 @@ pub extern "C" fn __wasi_fd_read(
         .map(|iov| unsafe { host::ciovec_to_nix_mut(iov) })
         .collect();
 
-    let full_nread = iovs.iter().map(|iov| iov.as_slice().len()).sum();
-
     let host_nread = match readv(fe.fd_object.rawfd, &mut iovs) {
         Ok(len) => len,
         Err(e) => return wasm32::errno_from_nix(e.as_errno().unwrap()),
     };
 
-    if host_nread < full_nread {
+    if host_nread == 0 {
         // we hit eof, so remove the fdentry from the context
         let mut fe = ctx.fds.remove(&fd).expect("file entry is still there");
         fe.fd_object.needs_close = false;


### PR DESCRIPTION
`fd_read()` should not close the descriptor after a short read.

`EOF` is only reached when `readv(2)` returns `0`.

Fixes #128