### PR TITLE
Fix sigaltstack(2) usage in lucet-runtime

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -59,9 +59,16 @@ impl Instance {
             SigStackFlags::empty(),
             libc::SIGSTKSZ,
         );
-        let saved_sigstack =
-            unsafe { sigaltstack(&guest_sigstack).expect("saving sigaltstack succeeds") };
-
+        let previous_sigstack = unsafe { sigaltstack(Some(guest_sigstack)) }
+            .expect("enabling or changing the signal stack succeeds");
+        if let Some(previous_sigstack) = previous_sigstack {
+            assert!(
+                !previous_sigstack
+                    .flags()
+                    .contains(SigStackFlags::SS_ONSTACK),
+                "an instance was created with a signal stack"
+            );
+        }
         let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
         if let Some(ref mut state) = *ostate {
             state.counter += 1;
@@ -81,7 +88,12 @@ impl Instance {
             if state.counter == 0 {
                 unsafe {
                     // restore the host signal stack
-                    sigaltstack(&saved_sigstack).expect("sigaltstack restoration succeeds");
+                    if !altstack_flags()
+                        .expect("the current stack flags could be retrieved")
+                        .contains(SigStackFlags::SS_ONSTACK)
+                    {
+                        sigaltstack(previous_sigstack).expect("sigaltstack restoration succeeds");
+                    }
                     restore_host_signal_state(state);
                 }
                 true
@@ -333,6 +345,14 @@ impl SigStack {
         SigStack { stack }
     }
 
+    pub fn disabled() -> SigStack {
+        let mut stack = unsafe { std::mem::uninitialized::<libc::stack_t>() };
+        stack.ss_sp = std::ptr::null_mut();
+        stack.ss_flags = SigStackFlags::SS_DISABLE.bits();
+        stack.ss_size = libc::SIGSTKSZ;
+        SigStack { stack }
+    }
+
     pub fn flags(&self) -> SigStackFlags {
         SigStackFlags::from_bits_truncate(self.stack.ss_flags)
     }
@@ -357,13 +377,35 @@ bitflags! {
     }
 }
 
-pub unsafe fn sigaltstack(ss: &SigStack) -> nix::Result<SigStack> {
-    let mut oldstack = std::mem::uninitialized::<libc::stack_t>();
-
+pub unsafe fn sigaltstack(new_sigstack: Option<SigStack>) -> nix::Result<Option<SigStack>> {
+    let mut previous_stack = std::mem::uninitialized::<libc::stack_t>();
+    let disabled_sigstack = SigStack::disabled();
+    let new_stack = match new_sigstack {
+        None => &disabled_sigstack.stack,
+        Some(ref new_stack) => &new_stack.stack,
+    };
     let res = libc::sigaltstack(
-        &ss.stack as *const libc::stack_t,
-        &mut oldstack as *mut libc::stack_t,
+        new_stack as *const libc::stack_t,
+        &mut previous_stack as *mut libc::stack_t,
     );
+    nix::errno::Errno::result(res).map(|_| {
+        let sigstack = SigStack {
+            stack: previous_stack,
+        };
+        if sigstack.flags().contains(SigStackFlags::SS_DISABLE) {
+            None
+        } else {
+            Some(sigstack)
+        }
+    })
+}
 
-    nix::errno::Errno::result(res).map(|_| SigStack { stack: oldstack })
+pub unsafe fn altstack_flags() -> nix::Result<SigStackFlags> {
+    let mut current_stack = std::mem::uninitialized::<libc::stack_t>();
+    let res = libc::sigaltstack(
+        std::ptr::null_mut(),
+        &mut current_stack as *mut libc::stack_t,
+    );
+    nix::errno::Errno::result(res)
+        .map(|_| SigStackFlags::from_bits_truncate(current_stack.ss_flags))
 }

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -677,6 +677,37 @@ macro_rules! guest_fault_tests {
             })
         }
 
+        #[test]
+        fn sigaltstack_restores() {
+            use libc::*;
+
+            test_nonex(|| {
+                // any alternate stack present before a thread runs an instance should be restored
+                // after the instance returns
+                let beforestack = unsafe {
+                    let mut beforestack = std::mem::uninitialized::<stack_t>();
+                    sigaltstack(std::ptr::null(), &mut beforestack as *mut stack_t);
+                    beforestack
+                };
+
+                let module = mock_traps_module();
+                let region =
+                    TestRegion::create(1, &Limits::default()).expect("region can be created");
+                let mut inst = region
+                    .new_instance(module)
+                    .expect("instance can be created");
+                run_onetwothree(&mut inst);
+
+                let afterstack = unsafe {
+                    let mut afterstack = std::mem::uninitialized::<stack_t>();
+                    sigaltstack(std::ptr::null(), &mut afterstack as *mut stack_t);
+                    afterstack
+                };
+
+                assert_eq!(beforestack.ss_sp, afterstack.ss_sp);
+            })
+        }
+
         // TODO: remove this once `nix` PR https://github.com/nix-rust/nix/pull/991 is merged
         pub unsafe fn mprotect(
             addr: *mut c_void,


### PR DESCRIPTION
`sigaltstack(2)`'s second argument is not exactly the "old" `stack_t` when registering a stack for signal handling.

Only the flags are supposed to be read, in order to know whether we currently are on the alternative stack, and/or if one has been set.

The regular stack is automatically restored after a signal handler returns.

Disabling an alternative stack should be done by passing the `SS_DISABLE` flag, not necessarily by copying what was returned in the optional second argument to the function.

Even on Linux, the address of the "old" `stack_t` appears to be always set to `NULL`, but it may be undefined. So it is not relevant, and is ignored when `SS_DISABLE` is set anyway.

On MacOS, providing the stack size is required, even with `SS_DISABLE`.

This commit changes a few things.

First, in instead of returning the "old" `stack_t`, our `sigaltstack(2)` wrapper now returns the current flags, as this is the only information actually being returned.

A new function to only get these flags is added, so we can avoid setting something that is already set.

A new constructor for the `SigStack` is also added, and sets the required values to disable the signal stack.

This fixes all previous Lucet's issues with signal handling on macOS.