### PR TITLE
Unfortunately, error strings are not very portable

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -216,7 +216,8 @@ impl ModuleInternal for DlModule {
 fn is_undefined_symbol(e: &std::io::Error) -> bool {
     // gross, but I'm not sure how else to differentiate this type of error from other
     // IO errors
-    format!("{}", e).contains("undefined symbol")
+    let msg = format!("{}", e);
+    msg.contains("undefined symbol") || msg.contains("symbol not found")
 }
 
 // TODO: PR to nix or libloading?


### PR DESCRIPTION
Here's another variant for an undefined symbol :(