### PR TITLE
Zero out instance magic more safely

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -658,6 +658,16 @@ macro_rules! alloc_tests {
                 }
             }
         }
+
+        #[test]
+        fn drop_region_first() {
+            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+            let inst = region
+                .new_instance(MockModuleBuilder::new().build())
+                .expect("new_instance succeeds");
+            drop(region);
+            drop(inst);
+        }
     };
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -134,10 +134,10 @@ impl Drop for InstanceHandle {
     fn drop(&mut self) {
         // run the destructor by taking and dropping the inner `Instance`
         unsafe {
-            mem::replace(self.inst.as_mut(), mem::uninitialized());
-            // make sure magic is zeroed, as we can't depend on `uninitialized` throwing away the
-            // magic
-            self.inst.as_mut().magic = 0;
+            // make sure magic is zeroed, but allow everything else to be uninitialized
+            let mut uninit: Instance = mem::uninitialized();
+            uninit.magic = 0;
+            mem::replace(self.inst.as_mut(), uninit);
         }
     }
 }

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn lucet_instance_reset(inst: *mut lucet_instance) -> luce
 
 #[no_mangle]
 pub unsafe extern "C" fn lucet_instance_release(inst: *mut lucet_instance) {
-    instance_handle_from_raw(inst as *mut Instance);
+    instance_handle_from_raw(inst as *mut Instance, true);
 }
 
 #[no_mangle]


### PR DESCRIPTION
This was previously segfaulting if the region got dropped after the `mem::replace` line. Our tests
previously always had the region remain in scope, which is why we didn't catch it till now