### PR TITLE
lucet-runtime-internals: replace our own si_addr method with libc-0.2.54

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -839,7 +839,7 @@ impl std::fmt::Display for State {
                     write!(
                         f,
                         " accessed memory at {:p} (inside heap guard)",
-                        siginfo.si_addr()
+                        siginfo.si_addr_ext()
                     )?;
                 }
                 Ok(())

--- a/lucet-runtime/lucet-runtime-internals/src/instance/siginfo_ext.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/siginfo_ext.rs
@@ -5,11 +5,11 @@ extern "C" {
 }
 
 pub trait SiginfoExt {
-    fn si_addr(&self) -> *const c_void;
+    fn si_addr_ext(&self) -> *const c_void;
 }
 
 impl SiginfoExt for siginfo_t {
-    fn si_addr(&self) -> *const c_void {
+    fn si_addr_ext(&self) -> *const c_void {
         unsafe { siginfo_si_addr(self as *const siginfo_t) }
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -189,7 +189,7 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
                 // If the trap was a segv or bus fault and the addressed memory was outside the
                 // guard pages, it is also a fatal error
                 let outside_guard = (siginfo.si_signo == SIGSEGV || siginfo.si_signo == SIGBUS)
-                    && !inst.alloc.addr_in_heap_guard(siginfo.si_addr());
+                    && !inst.alloc.addr_in_heap_guard(siginfo.si_addr_ext());
 
                 // record the fault and jump back to the host context
                 inst.state = State::Fault {


### PR DESCRIPTION
`libc-0.2.54` added a new method to `Siginfo` that is identical, aside from an `unsafe` annotation, to our `si_addr` method in the `SiginfoExt` trait. However, it only works on Linux. We rename our method to `si_addr_ext` so that it works again.

Fixes #170 