### PR TITLE
Add function import/export information to module data

### DIFF
--- a/benchmarks/lucet-benchmarks/src/modules.rs
+++ b/benchmarks/lucet-benchmarks/src/modules.rs
@@ -28,7 +28,7 @@ pub fn null_mock() -> Arc<dyn Module> {
     extern "C" fn f(_vmctx: *mut lucet_vmctx) {}
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new(b"f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
         .build()
 }
 
@@ -50,7 +50,7 @@ pub fn large_dense_heap_mock(heap_kb: usize) -> Arc<dyn Module> {
     });
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new(b"f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
         .with_initial_heap(heap.as_slice())
         .with_heap_spec(heap_spec)
         .build()
@@ -81,7 +81,7 @@ pub fn large_sparse_heap_mock(heap_kb: usize, stride: usize) -> Arc<dyn Module> 
         });
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new(b"f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
         .with_initial_heap(heap.as_slice())
         .with_heap_spec(heap_spec)
         .build()
@@ -102,7 +102,7 @@ pub fn fib_mock() -> Arc<dyn Module> {
     }
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new(b"f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
         .build()
 }
 
@@ -179,7 +179,7 @@ pub fn many_args_mock() -> Arc<dyn Module> {
     }
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new(b"f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
         .build()
 }
 
@@ -255,8 +255,8 @@ pub fn hostcalls_mock() -> Arc<dyn Module> {
 
     MockModuleBuilder::new()
         .with_export_func(
-            MockExportBuilder::new(b"wrapped", FunctionPointer::from_usize(wrapped as usize)))
+            MockExportBuilder::new("wrapped", FunctionPointer::from_usize(wrapped as usize)))
         .with_export_func(
-            MockExportBuilder::new(b"raw", FunctionPointer::from_usize(raw as usize)))
+            MockExportBuilder::new("raw", FunctionPointer::from_usize(raw as usize)))
         .build()
 }

--- a/benchmarks/lucet-benchmarks/src/par.rs
+++ b/benchmarks/lucet-benchmarks/src/par.rs
@@ -89,7 +89,7 @@ fn par_run<R: RegionCreate + 'static>(
             .unwrap()
             .install(|| {
                 handles.par_iter_mut().for_each(|handle| {
-                    handle.run(b"f", &[]).unwrap();
+                    handle.run("f", &[]).unwrap();
                 })
             })
     }

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -201,7 +201,7 @@ fn drop_instance_with_sparse_heap<R: RegionCreate + 'static>(c: &mut Criterion) 
 /// switching overhead.
 fn run_null<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
-        inst.run(b"f", &[]).unwrap();
+        inst.run("f", &[]).unwrap();
     }
 
     let module = null_mock();
@@ -222,7 +222,7 @@ fn run_null<R: RegionCreate + 'static>(c: &mut Criterion) {
 /// cost of the Lucet runtime.
 fn run_fib<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
-        inst.run(b"f", &[]).unwrap();
+        inst.run("f", &[]).unwrap();
     }
 
     let module = fib_mock();
@@ -240,7 +240,7 @@ fn run_fib<R: RegionCreate + 'static>(c: &mut Criterion) {
 /// Run a trivial WASI program.
 fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
-        inst.run(b"_start", &[]).unwrap();
+        inst.run("_start", &[]).unwrap();
     }
 
     let workdir = TempDir::new().expect("create working directory");
@@ -281,7 +281,7 @@ fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
 fn run_many_args<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
         inst.run(
-            b"f",
+            "f",
             &[
                 0xAFu8.into(),
                 0xAFu16.into(),
@@ -368,7 +368,7 @@ fn run_many_args<R: RegionCreate + 'static>(c: &mut Criterion) {
 
 fn run_hostcall_wrapped<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
-        inst.run(b"wrapped", &[]).unwrap();
+        inst.run("wrapped", &[]).unwrap();
     }
 
     let module = hostcalls_mock();
@@ -388,7 +388,7 @@ fn run_hostcall_wrapped<R: RegionCreate + 'static>(c: &mut Criterion) {
 
 fn run_hostcall_raw<R: RegionCreate + 'static>(c: &mut Criterion) {
     fn body(inst: &mut InstanceHandle) {
-        inst.run(b"raw", &[]).unwrap();
+        inst.run("raw", &[]).unwrap();
     }
 
     let module = hostcalls_mock();

--- a/lucet-module-data/src/functions.rs
+++ b/lucet-module-data/src/functions.rs
@@ -4,6 +4,44 @@ use serde::{Deserialize, Serialize};
 
 use std::slice::from_raw_parts;
 
+/// FunctionIndex is an identifier for a function, imported, exported, or external. The space of
+/// FunctionIndex is shared for all of these, so `FunctionIndex(N)` may identify exported function
+/// #2, `FunctionIndex(N + 1)` may identify an internal function, and `FunctionIndex(N + 2)` may
+/// identify an imported function.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct FunctionIndex(u32);
+
+impl FunctionIndex {
+    pub fn from_u32(idx: u32) -> FunctionIndex {
+        FunctionIndex(idx)
+    }
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+/// ImportFunction specifically ties a FunctionIndex to some imported function information together
+/// with a module that function should be found in.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+pub struct ImportFunction<'a> {
+    pub fn_idx: FunctionIndex,
+    pub module: &'a str
+}
+
+pub struct OwnedImportFunction {
+    pub fn_idx: FunctionIndex,
+    pub module: String
+}
+
+impl OwnedImportFunction {
+    pub fn to_ref<'a>(&'a self) -> ImportFunction<'a> {
+        ImportFunction {
+            fn_idx: self.fn_idx.clone(),
+            module: self.module.as_str()
+        }
+    }
+}
+
 /// UniqueSignatureIndex names a signature after collapsing duplicate signatures to a single
 /// identifier, whereas SignatureIndex is directly what the original module specifies, and may
 /// specify duplicates of types that are structurally equal.
@@ -58,7 +96,7 @@ impl OwnedFunctionMetadata {
 
 pub struct FunctionHandle {
     pub ptr: FunctionPointer,
-    pub id: u32
+    pub id: FunctionIndex
 }
 
 // The layout of this struct is very tightly coupled to lucetc's `write_function_manifest`!

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -15,7 +15,7 @@ pub use crate::error::Error;
 pub use crate::globals::{Global, GlobalDef, GlobalSpec};
 pub use crate::linear_memory::{HeapSpec, SparseData, LinearMemorySpec};
 pub use crate::module_data::ModuleData;
-pub use crate::functions::{FunctionHandle, FunctionMetadata, FunctionPointer, FunctionSpec, UniqueSignatureIndex};
+pub use crate::functions::{FunctionHandle, FunctionIndex, FunctionMetadata, FunctionPointer, FunctionSpec, ImportFunction, UniqueSignatureIndex};
 pub use crate::traps::{TrapManifest, TrapSite, TrapCode};
 pub use crate::types::{Signature, ValueType};
 
@@ -24,5 +24,5 @@ pub mod owned {
     pub use crate::globals::OwnedGlobalSpec;
     pub use crate::linear_memory::{OwnedSparseData, OwnedLinearMemorySpec};
     pub use crate::module_data::OwnedModuleData;
-    pub use crate::functions::OwnedFunctionMetadata;
+    pub use crate::functions::{OwnedFunctionMetadata, OwnedImportFunction};
 }

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -15,7 +15,7 @@ pub use crate::error::Error;
 pub use crate::globals::{Global, GlobalDef, GlobalSpec};
 pub use crate::linear_memory::{HeapSpec, SparseData, LinearMemorySpec};
 pub use crate::module_data::ModuleData;
-pub use crate::functions::{FunctionHandle, FunctionIndex, FunctionMetadata, FunctionPointer, FunctionSpec, ImportFunction, UniqueSignatureIndex};
+pub use crate::functions::{ExportFunction, FunctionHandle, FunctionIndex, FunctionMetadata, FunctionPointer, FunctionSpec, ImportFunction, UniqueSignatureIndex};
 pub use crate::traps::{TrapManifest, TrapSite, TrapCode};
 pub use crate::types::{Signature, ValueType};
 
@@ -24,5 +24,5 @@ pub mod owned {
     pub use crate::globals::OwnedGlobalSpec;
     pub use crate::linear_memory::{OwnedSparseData, OwnedLinearMemorySpec};
     pub use crate::module_data::OwnedModuleData;
-    pub use crate::functions::{OwnedFunctionMetadata, OwnedImportFunction};
+    pub use crate::functions::{OwnedFunctionMetadata, OwnedExportFunction, OwnedImportFunction};
 }

--- a/lucet-module-data/src/module_data.rs
+++ b/lucet-module-data/src/module_data.rs
@@ -1,5 +1,5 @@
 use crate::{
-    functions::{FunctionMetadata, OwnedFunctionMetadata},
+    functions::{FunctionIndex, FunctionMetadata, ImportFunction, OwnedFunctionMetadata},
     globals::GlobalSpec,
     linear_memory::{HeapSpec, LinearMemorySpec, SparseData},
     types::Signature,
@@ -23,6 +23,9 @@ pub struct ModuleData<'a> {
     globals_spec: Vec<GlobalSpec<'a>>,
     #[serde(borrow)]
     function_info: Vec<FunctionMetadata<'a>>,
+    #[serde(borrow)]
+    import_functions: Vec<ImportFunction<'a>>,
+    export_functions: Vec<FunctionIndex>,
     signatures: Vec<Signature>,
 }
 
@@ -31,12 +34,16 @@ impl<'a> ModuleData<'a> {
         linear_memory: Option<LinearMemorySpec<'a>>,
         globals_spec: Vec<GlobalSpec<'a>>,
         function_info: Vec<FunctionMetadata<'a>>,
+        import_functions: Vec<ImportFunction<'a>>,
+        export_functions: Vec<FunctionIndex>,
         signatures: Vec<Signature>,
     ) -> Self {
         Self {
             linear_memory,
             globals_spec,
             function_info,
+            import_functions,
+            export_functions,
             signatures,
         }
     }
@@ -61,25 +68,37 @@ impl<'a> ModuleData<'a> {
         &self.globals_spec
     }
 
+    pub fn function_info(&self) -> &[FunctionMetadata<'a>] {
+        &self.function_info
+    }
+
+    pub fn import_functions(&self) -> &[ImportFunction] {
+        &self.import_functions
+    }
+
+    pub fn export_functions(&self) -> &[FunctionIndex] {
+        &self.export_functions
+    }
+
     // Function index here is a different index space than `get_func_from_idx`, which
     // uses function index as an index into a table of function elements.
     //
     // This is an index of all functions in the module.
-    pub fn get_signature(&self, fn_id: u32) -> &Signature {
-        let sig_idx = self.function_info[fn_id as usize].signature;
+    pub fn get_signature(&self, fn_id: FunctionIndex) -> &Signature {
+        let sig_idx = self.function_info[fn_id.as_u32() as usize].signature;
         &self.signatures[sig_idx.as_u32() as usize]
     }
 
-    pub fn function_id_by_name(&self, name: &[u8]) -> Option<u32> {
+    pub fn function_id_by_name(&self, name: &[u8]) -> Option<FunctionIndex> {
         self.function_info
             .iter()
             .enumerate()
             .find(|(_, fn_meta)| { fn_meta.sym == Some(name) })
-            .map(|(i, _)| i as u32)
+            .map(|(i, _)| FunctionIndex::from_u32(i as u32))
     }
 
-    pub fn sym_for(&self, fn_id: u32) -> Option<&[u8]> {
-        self.function_info.get(fn_id as usize).and_then(|func| func.sym)
+    pub fn sym_for(&self, fn_id: FunctionIndex) -> Option<&[u8]> {
+        self.function_info[fn_id.as_u32() as usize].sym
     }
 
     pub fn signatures(&self) -> &[Signature] {
@@ -100,6 +119,7 @@ impl<'a> ModuleData<'a> {
 use crate::{
     globals::OwnedGlobalSpec,
     linear_memory::{OwnedLinearMemorySpec, OwnedSparseData},
+    functions::OwnedImportFunction,
 };
 
 /// The metadata (and some data) for a Lucet module.
@@ -111,6 +131,8 @@ pub struct OwnedModuleData {
     linear_memory: Option<OwnedLinearMemorySpec>,
     globals_spec: Vec<OwnedGlobalSpec>,
     function_info: Vec<OwnedFunctionMetadata>,
+    imports: Vec<OwnedImportFunction>,
+    exports: Vec<FunctionIndex>,
     signatures: Vec<Signature>,
 }
 
@@ -119,12 +141,16 @@ impl OwnedModuleData {
         linear_memory: Option<OwnedLinearMemorySpec>,
         globals_spec: Vec<OwnedGlobalSpec>,
         function_info: Vec<OwnedFunctionMetadata>,
+        imports: Vec<OwnedImportFunction>,
+        exports: Vec<FunctionIndex>,
         signatures: Vec<Signature>,
     ) -> Self {
         Self {
             linear_memory,
             globals_spec,
             function_info,
+            imports,
+            exports,
             signatures,
         }
     }
@@ -140,12 +166,14 @@ impl OwnedModuleData {
             },
             self.globals_spec.iter().map(|gs| gs.to_ref()).collect(),
             self.function_info.iter().map(|info| info.to_ref()).collect(),
+            self.imports.iter().map(|imp| imp.to_ref()).collect(),
+            self.exports.clone(),
             self.signatures.clone(),
         )
     }
 
     pub fn empty() -> Self {
-        Self::new(None, vec![], vec![], vec![])
+        Self::new(None, vec![], vec![], vec![], vec![], vec![])
     }
 
     pub fn with_heap_spec(mut self, heap_spec: HeapSpec) -> Self {

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -286,11 +286,11 @@ impl Instance {
     /// # use lucet_runtime_internals::instance::InstanceHandle;
     /// # let instance: InstanceHandle = unimplemented!();
     /// // regular execution yields `Ok(UntypedRetVal)`
-    /// let retval = instance.run(b"factorial", &[5u64.into()]).unwrap();
+    /// let retval = instance.run("factorial", &[5u64.into()]).unwrap();
     /// assert_eq!(u64::from(retval), 120u64);
     ///
     /// // runtime faults yield `Err(Error)`
-    /// let result = instance.run(b"faulting_function", &[]);
+    /// let result = instance.run("faulting_function", &[]);
     /// assert!(result.is_err());
     /// ```
     ///
@@ -310,15 +310,8 @@ impl Instance {
     ///
     /// For the moment, we do not mark this as `unsafe` in the Rust type system, but that may change
     /// in the future.
-    pub fn run(&mut self, entrypoint: &[u8], args: &[Val]) -> Result<UntypedRetVal, Error> {
-        let func = self
-            .module
-            .get_export_func(std::str::from_utf8(entrypoint).map_err(|_| {
-                // This could make for ambiguous errors in an unlikely scenario:
-                // if a symbol "foo" exists, but an entrypoint like "f\x00oo" is provided
-                // where "from_utf8_lossy" ends up providing a string for a symbol that exists
-                Error::SymbolNotFound(String::from_utf8_lossy(entrypoint).to_string())
-            })?)?;
+    pub fn run(&mut self, entrypoint: &str, args: &[Val]) -> Result<UntypedRetVal, Error> {
+        let func = self.module.get_export_func(entrypoint)?;
         self.run_func(func, &args)
     }
 

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -56,7 +56,7 @@ pub trait ModuleInternal: Send + Sync {
     /// Get the table elements from the module.
     fn table_elements(&self) -> Result<&[TableElement], Error>;
 
-    fn get_export_func(&self, sym: &[u8]) -> Result<FunctionHandle, Error>;
+    fn get_export_func(&self, sym: &str) -> Result<FunctionHandle, Error>;
 
     fn get_func_from_idx(&self, table_id: u32, func_id: u32) -> Result<FunctionHandle, Error>;
 

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -5,8 +5,8 @@ mod sparse_page_data;
 pub use crate::module::dl::DlModule;
 pub use crate::module::mock::{MockExportBuilder, MockModuleBuilder};
 pub use lucet_module_data::{
-    FunctionHandle, FunctionPointer, FunctionSpec, Global, GlobalSpec, HeapSpec, Signature,
-    TrapCode, TrapManifest, ValueType,
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, Global, GlobalSpec, HeapSpec,
+    Signature, TrapCode, TrapManifest, ValueType,
 };
 
 use crate::alloc::Limits;
@@ -66,7 +66,7 @@ pub trait ModuleInternal: Send + Sync {
 
     fn addr_details(&self, addr: *const c_void) -> Result<Option<AddrDetails>, Error>;
 
-    fn get_signature(&self, fn_id: u32) -> &Signature;
+    fn get_signature(&self, fn_id: FunctionIndex) -> &Signature;
 
     fn function_handle_from_ptr(&self, ptr: FunctionPointer) -> FunctionHandle {
         let id = self
@@ -74,7 +74,7 @@ pub trait ModuleInternal: Send + Sync {
             .iter()
             .enumerate()
             .find(|(_, fn_spec)| fn_spec.ptr() == ptr)
-            .map(|(fn_id, _)| fn_id as u32)
+            .map(|(fn_id, _)| FunctionIndex::from_u32(fn_id as u32))
             .expect("valid function pointer");
 
         FunctionHandle { ptr, id }

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -2,7 +2,9 @@ use crate::error::Error;
 use crate::module::{AddrDetails, GlobalSpec, HeapSpec, Module, ModuleInternal, TableElement};
 use libc::c_void;
 use libloading::{Library, Symbol};
-use lucet_module_data::{FunctionHandle, FunctionPointer, FunctionSpec, ModuleData, Signature};
+use lucet_module_data::{
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, Signature,
+};
 use std::ffi::CStr;
 use std::mem;
 use std::path::Path;
@@ -173,7 +175,7 @@ impl ModuleInternal for DlModule {
             .function_id_by_name(&guest_sym)
             .ok_or_else(|| Error::SymbolNotFound(String::from_utf8_lossy(sym).into_owned()))
             .map(|id| {
-                let ptr = self.function_manifest()[id as usize].ptr();
+                let ptr = self.function_manifest()[id.as_u32() as usize].ptr();
                 FunctionHandle { ptr, id }
             })
     }
@@ -233,7 +235,7 @@ impl ModuleInternal for DlModule {
         }
     }
 
-    fn get_signature(&self, fn_id: u32) -> &Signature {
+    fn get_signature(&self, fn_id: FunctionIndex) -> &Signature {
         self.module_data.get_signature(fn_id)
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -167,13 +167,10 @@ impl ModuleInternal for DlModule {
         Ok(unsafe { from_raw_parts(*p_table_segment, **p_table_segment_len as usize) })
     }
 
-    fn get_export_func(&self, sym: &[u8]) -> Result<FunctionHandle, Error> {
-        let mut guest_sym: Vec<u8> = b"guest_func_".to_vec();
-        guest_sym.extend_from_slice(sym);
-
+    fn get_export_func(&self, sym: &str) -> Result<FunctionHandle, Error> {
         self.module_data
-            .function_id_by_name(&guest_sym)
-            .ok_or_else(|| Error::SymbolNotFound(String::from_utf8_lossy(sym).into_owned()))
+            .get_export_func_id(sym)
+            .ok_or_else(|| Error::SymbolNotFound(sym.to_string()))
             .map(|id| {
                 let ptr = self.function_manifest()[id.as_u32() as usize].ptr();
                 FunctionHandle { ptr, id }

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -2,12 +2,12 @@ use crate::error::Error;
 use crate::module::{AddrDetails, GlobalSpec, HeapSpec, Module, ModuleInternal, TableElement};
 use libc::c_void;
 use lucet_module_data::owned::{
-    OwnedFunctionMetadata, OwnedGlobalSpec, OwnedImportFunction, OwnedLinearMemorySpec,
-    OwnedModuleData, OwnedSparseData,
+    OwnedExportFunction, OwnedFunctionMetadata, OwnedGlobalSpec, OwnedImportFunction,
+    OwnedLinearMemorySpec, OwnedModuleData, OwnedSparseData,
 };
 use lucet_module_data::{
-    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, Signature, TrapSite,
-    UniqueSignatureIndex,
+    ExportFunction, FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData,
+    Signature, TrapSite, UniqueSignatureIndex,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -18,13 +18,13 @@ pub struct MockModuleBuilder {
     sparse_page_data: Vec<Option<Vec<u8>>>,
     globals: BTreeMap<usize, OwnedGlobalSpec>,
     table_elements: BTreeMap<usize, TableElement>,
-    export_funcs: HashMap<Vec<u8>, FunctionPointer>,
+    export_funcs: HashMap<&'static str, FunctionPointer>,
     func_table: HashMap<(u32, u32), FunctionPointer>,
     start_func: Option<FunctionPointer>,
     function_manifest: Vec<FunctionSpec>,
     function_info: Vec<OwnedFunctionMetadata>,
     imports: Vec<OwnedImportFunction>,
-    exports: Vec<FunctionIndex>,
+    exports: Vec<OwnedExportFunction>,
     signatures: Vec<Signature>,
 }
 
@@ -122,15 +122,16 @@ impl MockModuleBuilder {
     }
 
     pub fn with_export_func(mut self, export: MockExportBuilder) -> Self {
-        self.export_funcs
-            .insert(export.sym().to_vec(), export.func());
+        self.export_funcs.insert(export.sym(), export.func());
         let sig_idx = self.record_sig(export.sig());
         self.function_info.push(OwnedFunctionMetadata {
             signature: sig_idx,
-            sym: Some(export.sym().to_vec()),
+            name: Some(export.sym().to_string()),
         });
-        self.exports
-            .push(FunctionIndex::from_u32(self.function_manifest.len() as u32));
+        self.exports.push(OwnedExportFunction {
+            fn_idx: FunctionIndex::from_u32(self.function_manifest.len() as u32),
+            names: vec![export.sym().to_string()],
+        });
         self.function_manifest.push(FunctionSpec::new(
             export.func().as_usize() as u64,
             export.func_len() as u32,
@@ -217,7 +218,7 @@ pub struct MockModule {
     serialized_module_data: Vec<u8>,
     module_data: ModuleData<'static>,
     pub table_elements: Vec<TableElement>,
-    pub export_funcs: HashMap<Vec<u8>, FunctionPointer>,
+    pub export_funcs: HashMap<&'static str, FunctionPointer>,
     pub func_table: HashMap<(u32, u32), FunctionPointer>,
     pub start_func: Option<FunctionPointer>,
     pub function_manifest: Vec<FunctionSpec>,
@@ -253,10 +254,11 @@ impl ModuleInternal for MockModule {
         Ok(&self.table_elements)
     }
 
-    fn get_export_func(&self, sym: &[u8]) -> Result<FunctionHandle, Error> {
-        let ptr = *self.export_funcs.get(sym).ok_or(Error::SymbolNotFound(
-            String::from_utf8_lossy(sym).into_owned(),
-        ))?;
+    fn get_export_func(&self, sym: &str) -> Result<FunctionHandle, Error> {
+        let ptr = *self
+            .export_funcs
+            .get(sym)
+            .ok_or(Error::SymbolNotFound(sym.to_string()))?;
 
         Ok(self.function_handle_from_ptr(ptr))
     }
@@ -293,7 +295,7 @@ impl ModuleInternal for MockModule {
 }
 
 pub struct MockExportBuilder {
-    sym: &'static [u8],
+    sym: &'static str,
     func: FunctionPointer,
     func_len: Option<usize>,
     traps: Option<&'static [TrapSite]>,
@@ -301,7 +303,7 @@ pub struct MockExportBuilder {
 }
 
 impl MockExportBuilder {
-    pub fn new(name: &'static [u8], func: FunctionPointer) -> MockExportBuilder {
+    pub fn new(name: &'static str, func: FunctionPointer) -> MockExportBuilder {
         MockExportBuilder {
             sym: name,
             func: func,
@@ -329,7 +331,7 @@ impl MockExportBuilder {
         self
     }
 
-    pub fn sym(&self) -> &'static [u8] {
+    pub fn sym(&self) -> &'static str {
         self.sym
     }
     pub fn func(&self) -> FunctionPointer {

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -6,8 +6,8 @@ use lucet_module_data::owned::{
     OwnedLinearMemorySpec, OwnedModuleData, OwnedSparseData,
 };
 use lucet_module_data::{
-    ExportFunction, FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData,
-    Signature, TrapSite, UniqueSignatureIndex,
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, Signature, TrapSite,
+    UniqueSignatureIndex,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -210,7 +210,7 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"add_2", &[123u64.into(), 456u64.into()])
+                .run("add_2", &[123u64.into(), 456u64.into()])
                 .expect("instance runs");
 
             assert_eq!(u64::from(retval), 123u64 + 456);
@@ -240,7 +240,7 @@ macro_rules! entrypoint_tests {
             // order is correct.
             let retval = inst
                 .run(
-                    b"add_10",
+                    "add_10",
                     &[
                         1u64.into(),
                         2u64.into(),
@@ -276,7 +276,7 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"mul_2", &[123u64.into(), 456u64.into()])
+                .run("mul_2", &[123u64.into(), 456u64.into()])
                 .expect("instance runs");
 
             assert_eq!(u64::from(retval), 123 * 456);
@@ -294,13 +294,13 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"add_2", &[111u64.into(), 222u64.into()])
+                .run("add_2", &[111u64.into(), 222u64.into()])
                 .expect("instance runs");
 
             assert_eq!(u64::from(retval), 111 + 222);
 
             let retval = inst
-                .run(b"mul_2", &[333u64.into(), 444u64.into()])
+                .run("mul_2", &[333u64.into(), 444u64.into()])
                 .expect("instance runs");
 
             assert_eq!(u64::from(retval), 333 * 444);
@@ -322,7 +322,7 @@ macro_rules! entrypoint_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"invalid", &[123u64.into(), 456u64.into()]) {
+            match inst.run("invalid", &[123u64.into(), 456u64.into()]) {
                 Err(Error::SymbolNotFound(sym)) => assert_eq!(sym, "invalid"),
                 res => panic!("unexpected result: {:?}", res),
             }
@@ -344,7 +344,7 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"add_f32_2", &[(-6.9f32).into(), 4.2f32.into()])
+                .run("add_f32_2", &[(-6.9f32).into(), 4.2f32.into()])
                 .expect("instance runs");
 
             assert_eq!(f32::from(retval), -6.9 + 4.2);
@@ -365,7 +365,7 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"add_f64_2", &[(-6.9f64).into(), 4.2f64.into()])
+                .run("add_f64_2", &[(-6.9f64).into(), 4.2f64.into()])
                 .expect("instance runs");
 
             assert_eq!(f64::from(retval), -6.9 + 4.2);
@@ -387,7 +387,7 @@ macro_rules! entrypoint_tests {
 
             let retval = inst
                 .run(
-                    b"add_f32_10",
+                    "add_f32_10",
                     &[
                         0.1f32.into(),
                         0.2f32.into(),
@@ -425,7 +425,7 @@ macro_rules! entrypoint_tests {
 
             let retval = inst
                 .run(
-                    b"add_f64_10",
+                    "add_f64_10",
                     &[
                         0.1f64.into(),
                         0.2f64.into(),
@@ -460,7 +460,7 @@ macro_rules! entrypoint_tests {
 
             let retval = inst
                 .run(
-                    b"add_mixed_20",
+                    "add_mixed_20",
                     &[
                         (-1.1f64).into(),
                         1u8.into(),
@@ -527,7 +527,7 @@ macro_rules! entrypoint_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"add_2", &[123.0f64.into(), 456.0f64.into()]) {
+            match inst.run("add_2", &[123.0f64.into(), 456.0f64.into()]) {
                 Err(Error::InvalidArgument(err)) => {
                     assert_eq!(err, "entrypoint function signature mismatch")
                 }
@@ -551,7 +551,7 @@ macro_rules! entrypoint_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"add_2", &[123u64.into()]) {
+            match inst.run("add_2", &[123u64.into()]) {
                 Err(Error::InvalidArgument(err)) => assert_eq!(
                     err,
                     "entrypoint function signature mismatch (number of arguments is incorrect)"
@@ -576,7 +576,7 @@ macro_rules! entrypoint_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"add_2", &[123u64.into(), 456u64.into(), 789u64.into()]) {
+            match inst.run("add_2", &[123u64.into(), 456u64.into(), 789u64.into()]) {
                 Err(Error::InvalidArgument(err)) => assert_eq!(
                     err,
                     "entrypoint function signature mismatch (number of arguments is incorrect)"
@@ -611,7 +611,7 @@ macro_rules! entrypoint_tests {
             // This function will call `malloc` for the given size, then `memset` the entire region to the
             // init_as argument. The pointer to the allocated region gets stored in loc_outval.
             inst.run(
-                b"create_and_memset",
+                "create_and_memset",
                 &[
                     // int init_as
                     TEST_REGION_INIT_VAL.into(),
@@ -662,7 +662,7 @@ macro_rules! entrypoint_tests {
 
             // Create a region and initialize it, just like above
             inst.run(
-                b"create_and_memset",
+                "create_and_memset",
                 &[
                     // int init_as
                     TEST_REGION_INIT_VAL.into(),
@@ -692,7 +692,7 @@ macro_rules! entrypoint_tests {
             }
 
             // Then increment the first location in the region
-            inst.run(b"increment_ptr", &[Val::GuestPtr(loc_region_1)])
+            inst.run("increment_ptr", &[Val::GuestPtr(loc_region_1)])
                 .expect("instance runs");
 
             let heap = inst.heap();
@@ -737,7 +737,7 @@ macro_rules! entrypoint_tests {
 
             // same as above
             inst.run(
-                b"create_and_memset",
+                "create_and_memset",
                 &[
                     // int init_as
                     TEST_REGION_INIT_VAL.into(),
@@ -757,7 +757,7 @@ macro_rules! entrypoint_tests {
 
             // Create a second region
             inst.run(
-                b"create_and_memset",
+                "create_and_memset",
                 &[
                     // int init_as
                     TEST_REGION2_INIT_VAL.into(),
@@ -815,7 +815,7 @@ macro_rules! entrypoint_tests {
 
             // Run the setup routine
             inst.run(
-                b"ctype_setup",
+                "ctype_setup",
                 &[
                     std::ptr::null::<c_void>().into(),
                     Val::GuestPtr(loc_ctxstar),
@@ -831,7 +831,7 @@ macro_rules! entrypoint_tests {
             assert!(ctxstar > 0);
 
             // Run the body routine
-            inst.run(b"ctype_body", &[Val::GuestPtr(ctxstar)])
+            inst.run("ctype_body", &[Val::GuestPtr(ctxstar)])
                 .expect("instance runs");
         }
 
@@ -864,7 +864,7 @@ macro_rules! entrypoint_tests {
                 .expect("instance can be created");
 
             let retval = inst
-                .run(b"callback_entrypoint", &[0u64.into()])
+                .run("callback_entrypoint", &[0u64.into()])
                 .expect("instance runs");
             assert_eq!(u64::from(retval), 3);
         }

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -121,35 +121,29 @@ pub fn mock_calculator_module() -> Arc<dyn Module> {
 
     MockModuleBuilder::new()
         .with_export_func(
-            MockExportBuilder::new(b"add_2", FunctionPointer::from_usize(add_2 as usize))
+            MockExportBuilder::new("add_2", FunctionPointer::from_usize(add_2 as usize))
                 .with_sig(lucet_signature!((I64, I64) -> I64)),
         )
         .with_export_func(
-            MockExportBuilder::new(b"add_10", FunctionPointer::from_usize(add_10 as usize))
+            MockExportBuilder::new("add_10", FunctionPointer::from_usize(add_10 as usize))
                 .with_sig(lucet_signature!(
                     (I64, I64, I64, I64, I64, I64, I64, I64, I64, I64) -> I64)),
         )
         .with_export_func(
-            MockExportBuilder::new(b"mul_2", FunctionPointer::from_usize(mul_2 as usize))
+            MockExportBuilder::new("mul_2", FunctionPointer::from_usize(mul_2 as usize))
                 .with_sig(lucet_signature!((I64, I64) -> I64)),
         )
         .with_export_func(
-            MockExportBuilder::new(
-                b"add_f32_2",
-                FunctionPointer::from_usize(add_f32_2 as usize),
-            )
-            .with_sig(lucet_signature!((F32, F32) -> F32)),
+            MockExportBuilder::new("add_f32_2", FunctionPointer::from_usize(add_f32_2 as usize))
+                .with_sig(lucet_signature!((F32, F32) -> F32)),
+        )
+        .with_export_func(
+            MockExportBuilder::new("add_f64_2", FunctionPointer::from_usize(add_f64_2 as usize))
+                .with_sig(lucet_signature!((F64, F64) -> F64)),
         )
         .with_export_func(
             MockExportBuilder::new(
-                b"add_f64_2",
-                FunctionPointer::from_usize(add_f64_2 as usize),
-            )
-            .with_sig(lucet_signature!((F64, F64) -> F64)),
-        )
-        .with_export_func(
-            MockExportBuilder::new(
-                b"add_f32_10",
+                "add_f32_10",
                 FunctionPointer::from_usize(add_f32_10 as usize),
             )
             .with_sig(lucet_signature!(
@@ -157,7 +151,7 @@ pub fn mock_calculator_module() -> Arc<dyn Module> {
         )
         .with_export_func(
             MockExportBuilder::new(
-                b"add_f64_10",
+                "add_f64_10",
                 FunctionPointer::from_usize(add_f64_10 as usize),
             )
             .with_sig(lucet_signature!(
@@ -165,7 +159,7 @@ pub fn mock_calculator_module() -> Arc<dyn Module> {
         )
         .with_export_func(
             MockExportBuilder::new(
-                b"add_mixed_20",
+                "add_mixed_20",
                 FunctionPointer::from_usize(add_mixed_20 as usize),
             )
             .with_sig(lucet_signature!(

--- a/lucet-runtime/lucet-runtime-tests/src/globals.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/globals.rs
@@ -84,15 +84,15 @@ macro_rules! globals_tests {
                 .with_global(0, -1)
                 .with_global(1, 420)
                 .with_export_func(
-                    MockExportBuilder::new(b"get_global0", FunctionPointer::from_usize(get_global0 as usize))
+                    MockExportBuilder::new("get_global0", FunctionPointer::from_usize(get_global0 as usize))
                         .with_sig(lucet_signature!(() -> I64))
                 )
                 .with_export_func(
-                    MockExportBuilder::new(b"set_global0", FunctionPointer::from_usize(set_global0 as usize))
+                    MockExportBuilder::new("set_global0", FunctionPointer::from_usize(set_global0 as usize))
                         .with_sig(lucet_signature!((I64) -> ()))
                 )
                 .with_export_func(
-                    MockExportBuilder::new(b"get_global1", FunctionPointer::from_usize(get_global1 as usize))
+                    MockExportBuilder::new("get_global1", FunctionPointer::from_usize(get_global1 as usize))
                         .with_sig(lucet_signature!(() -> I64))
                 )
                 .build()

--- a/lucet-runtime/lucet-runtime-tests/src/globals.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/globals.rs
@@ -18,7 +18,7 @@ macro_rules! globals_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             // Now the globals should be:
             // $x = 3
@@ -32,7 +32,7 @@ macro_rules! globals_tests {
             let heap_u32 = unsafe { inst.heap_u32() };
             assert_eq!(heap_u32[0..=2], [4, 5, 6]);
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             // now heap should be:
             // [0] = 3
@@ -121,7 +121,7 @@ macro_rules! globals_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            let retval = inst.run(b"get_global0", &[]).expect("instance runs");
+            let retval = inst.run("get_global0", &[]).expect("instance runs");
             assert_eq!(i64::from(retval), -1);
         }
 
@@ -133,10 +133,10 @@ macro_rules! globals_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            let retval = inst.run(b"get_global0", &[]).expect("instance runs");
+            let retval = inst.run("get_global0", &[]).expect("instance runs");
             assert_eq!(i64::from(retval), -1);
 
-            let retval = inst.run(b"get_global1", &[]).expect("instance runs");
+            let retval = inst.run("get_global1", &[]).expect("instance runs");
             assert_eq!(i64::from(retval), 420);
         }
 
@@ -148,10 +148,10 @@ macro_rules! globals_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"set_global0", &[666i64.into()])
+            inst.run("set_global0", &[666i64.into()])
                 .expect("instance runs");
 
-            let retval = inst.run(b"get_global0", &[]).expect("instance runs");
+            let retval = inst.run("get_global0", &[]).expect("instance runs");
             assert_eq!(i64::from(retval), 666);
         }
     };

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -194,7 +194,7 @@ macro_rules! guest_fault_tests {
         }
 
         fn run_onetwothree(inst: &mut Instance) {
-            let retval = inst.run(b"onetwothree", &[]).expect("instance runs");
+            let retval = inst.run("onetwothree", &[]).expect("instance runs");
             assert_eq!(libc::c_int::from(retval), 123);
         }
 
@@ -208,7 +208,7 @@ macro_rules! guest_fault_tests {
                     .new_instance(module)
                     .expect("instance can be created");
 
-                match inst.run(b"illegal_instr", &[]) {
+                match inst.run("illegal_instr", &[]) {
                     Err(Error::RuntimeFault(details)) => {
                         assert_eq!(details.trapcode, Some(TrapCode::BadSignature));
                     }
@@ -232,7 +232,7 @@ macro_rules! guest_fault_tests {
                     .new_instance(module)
                     .expect("instance can be created");
 
-                match inst.run(b"oob", &[]) {
+                match inst.run("oob", &[]) {
                     Err(Error::RuntimeFault(details)) => {
                         assert_eq!(details.trapcode, Some(TrapCode::HeapOutOfBounds));
                     }
@@ -256,7 +256,7 @@ macro_rules! guest_fault_tests {
                     .new_instance(module)
                     .expect("instance can be created");
 
-                match inst.run(b"hostcall_main", &[]) {
+                match inst.run("hostcall_main", &[]) {
                     Err(Error::RuntimeTerminated(term)) => {
                         assert_eq!(
                             *term
@@ -317,7 +317,7 @@ macro_rules! guest_fault_tests {
                 // returns. This will initially cause a segfault. The signal handler will recover
                 // from the segfault, map the page to read/write, and then return to the child
                 // code. The child code will then succeed, and the instance will exit successfully.
-                inst.run(b"recoverable_fatal", &[]).expect("instance runs");
+                inst.run("recoverable_fatal", &[]).expect("instance runs");
 
                 unsafe { recoverable_ptr_teardown() };
                 drop(lock);
@@ -362,7 +362,7 @@ macro_rules! guest_fault_tests {
                         // returns. This will initially cause a segfault. The signal handler will recover
                         // from the segfault, map the page to read/write, and then return to the child
                         // code. The child code will then succeed, and the instance will exit successfully.
-                        match inst.run(b"recoverable_fatal", &[]) {
+                        match inst.run("recoverable_fatal", &[]) {
                             Err(Error::RuntimeTerminated(_)) => (),
                             res => panic!("unexpected result: {:?}", res),
                         }
@@ -417,7 +417,7 @@ macro_rules! guest_fault_tests {
                 );
                 unsafe { sigaction(Signal::SIGSEGV, &sa).expect("sigaction succeeds") };
 
-                match inst.run(b"illegal_instr", &[]) {
+                match inst.run("illegal_instr", &[]) {
                     Err(Error::RuntimeFault(details)) => {
                         assert_eq!(details.trapcode, Some(TrapCode::BadSignature));
                     }
@@ -486,7 +486,7 @@ macro_rules! guest_fault_tests {
                         nix::unistd::alarm::set(1);
 
                         // run guest code that loops forever
-                        inst.run(b"infinite_loop", &[]).expect("instance runs");
+                        inst.run("infinite_loop", &[]).expect("instance runs");
                         // show that we never get here
                         std::process::exit(1);
                     }
@@ -556,7 +556,7 @@ macro_rules! guest_fault_tests {
                         .new_instance(module)
                         .expect("instance can be created");
 
-                    inst.run(b"sleepy_guest", &[]).expect("instance runs");
+                    inst.run("sleepy_guest", &[]).expect("instance runs");
                 });
 
                 // now trigger a segfault in the middle of running the guest
@@ -606,7 +606,7 @@ macro_rules! guest_fault_tests {
                                 .new_instance(module)
                                 .expect("instance can be created");
 
-                            inst.run(b"infinite_loop", &[]).expect("instance runs");
+                            inst.run("infinite_loop", &[]).expect("instance runs");
                             unreachable!()
                         });
 
@@ -646,7 +646,7 @@ macro_rules! guest_fault_tests {
                         // Child code should run code that will make an OOB beyond the guard page. This will
                         // cause the entire process to abort before returning from `run`
                         inst.set_fatal_handler(handler);
-                        inst.run(b"fatal", &[]).expect("instance runs");
+                        inst.run("fatal", &[]).expect("instance runs");
                         // Show that we never get here:
                         std::process::exit(1);
                     }
@@ -681,7 +681,7 @@ macro_rules! guest_fault_tests {
                         // Child code should run code that will make an OOB beyond the guard page. This will
                         // cause the entire process to abort before returning from `run`
                         inst.set_fatal_handler(fatal_handler_exit);
-                        inst.run(b"fatal", &[]).expect("instance runs");
+                        inst.run("fatal", &[]).expect("instance runs");
                         // Show that we never get here:
                         std::process::exit(1);
                     }

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -85,36 +85,36 @@ pub fn mock_traps_module() -> Arc<dyn Module> {
 
     MockModuleBuilder::new()
         .with_export_func(MockExportBuilder::new(
-            b"onetwothree",
+            "onetwothree",
             FunctionPointer::from_usize(onetwothree as usize),
         ))
         .with_export_func(
             MockExportBuilder::new(
-                b"illegal_instr",
+                "illegal_instr",
                 FunctionPointer::from_usize(guest_func_illegal_instr as usize),
             )
             .with_func_len(11)
             .with_traps(ILLEGAL_INSTR_TRAPS),
         )
         .with_export_func(
-            MockExportBuilder::new(b"oob", FunctionPointer::from_usize(guest_func_oob as usize))
+            MockExportBuilder::new("oob", FunctionPointer::from_usize(guest_func_oob as usize))
                 .with_func_len(41)
                 .with_traps(OOB_TRAPS),
         )
         .with_export_func(MockExportBuilder::new(
-            b"hostcall_main",
+            "hostcall_main",
             FunctionPointer::from_usize(hostcall_main as usize),
         ))
         .with_export_func(MockExportBuilder::new(
-            b"infinite_loop",
+            "infinite_loop",
             FunctionPointer::from_usize(infinite_loop as usize),
         ))
         .with_export_func(MockExportBuilder::new(
-            b"fatal",
+            "fatal",
             FunctionPointer::from_usize(fatal as usize),
         ))
         .with_export_func(MockExportBuilder::new(
-            b"recoverable_fatal",
+            "recoverable_fatal",
             FunctionPointer::from_usize(recoverable_fatal as usize),
         ))
         .build()
@@ -546,7 +546,7 @@ macro_rules! guest_fault_tests {
                 let child = std::thread::spawn(|| {
                     let module = MockModuleBuilder::new()
                         .with_export_func(MockExportBuilder::new(
-                            b"sleepy_guest",
+                            "sleepy_guest",
                             FunctionPointer::from_usize(sleepy_guest as usize),
                         ))
                         .build();

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -219,7 +219,7 @@ macro_rules! host_tests {
 
             let module = MockModuleBuilder::new()
                 .with_export_func(MockExportBuilder::new(
-                    b"f",
+                    "f",
                     FunctionPointer::from_usize(f as usize),
                 ))
                 .build();
@@ -251,7 +251,7 @@ macro_rules! host_tests {
 
             let module = MockModuleBuilder::new()
                 .with_export_func(MockExportBuilder::new(
-                    b"f",
+                    "f",
                     FunctionPointer::from_usize(f as usize),
                 ))
                 .build();
@@ -283,7 +283,7 @@ macro_rules! host_tests {
 
             let module = MockModuleBuilder::new()
                 .with_export_func(MockExportBuilder::new(
-                    b"f",
+                    "f",
                     FunctionPointer::from_usize(f as usize),
                 ))
                 .build();

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -119,7 +119,7 @@ macro_rules! host_tests {
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-            inst.run(b"main", &[0u32.into(), 0i32.into()])
+            inst.run("main", &[0u32.into(), 0i32.into()])
                 .expect("instance runs");
         }
 
@@ -134,7 +134,7 @@ macro_rules! host_tests {
                 .build()
                 .expect("instance can be created");
 
-            inst.run(b"main", &[0u32.into(), 0i32.into()])
+            inst.run("main", &[0u32.into(), 0i32.into()])
                 .expect("instance runs");
 
             assert!(*inst.get_embed_ctx::<bool>().unwrap().unwrap());
@@ -148,7 +148,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"main", &[0u32.into(), 0i32.into()]) {
+            match inst.run("main", &[0u32.into(), 0i32.into()]) {
                 Err(Error::RuntimeTerminated(term)) => {
                     assert_eq!(
                         *term
@@ -172,7 +172,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"main", &[0u32.into(), 0u32.into()]) {
+            match inst.run("main", &[0u32.into(), 0u32.into()]) {
                 Err(Error::RuntimeTerminated(term)) => {
                     assert_eq!(
                         *term
@@ -197,7 +197,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"trigger_div_error", &[0u32.into()]) {
+            match inst.run("trigger_div_error", &[0u32.into()]) {
                 Err(Error::RuntimeFault(details)) => {
                     assert_eq!(details.trapcode, Some(TrapCode::IntegerDivByZero));
                 }
@@ -229,7 +229,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"f", &[]) {
+            match inst.run("f", &[]) {
                 Err(Error::RuntimeTerminated(details)) => {
                     assert_eq!(details, TerminationDetails::BorrowError("heap_mut"));
                 }
@@ -261,7 +261,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"f", &[]) {
+            match inst.run("f", &[]) {
                 Err(Error::RuntimeTerminated(details)) => {
                     assert_eq!(details, TerminationDetails::CtxNotFound);
                 }
@@ -293,7 +293,7 @@ macro_rules! host_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            let retval = inst.run(b"f", &[]).expect("instance runs");
+            let retval = inst.run("f", &[]).expect("instance runs");
             assert_eq!(bool::from(retval), true);
         }
     };

--- a/lucet-runtime/lucet-runtime-tests/src/memory.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/memory.rs
@@ -16,7 +16,7 @@ macro_rules! memory_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            let retval = inst.run(b"main", &[]).expect("instance runs");
+            let retval = inst.run("main", &[]).expect("instance runs");
             assert_eq!(u32::from(retval), 4);
         }
 
@@ -29,7 +29,7 @@ macro_rules! memory_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             let heap = inst.heap_u32();
             // guest puts the result of the grow_memory(1) call in heap[0]; based on the current settings,

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -96,7 +96,7 @@ macro_rules! stack_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"localpalooza", &[recursion_depth.into()])
+            inst.run("localpalooza", &[recursion_depth.into()])
         }
 
         fn expect_ok(module: Arc<DlModule>, recursion_depth: i32) {

--- a/lucet-runtime/lucet-runtime-tests/src/start.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/start.rs
@@ -15,7 +15,7 @@ macro_rules! start_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             // Now the globals should be:
             // $flossie = 17
@@ -35,7 +35,7 @@ macro_rules! start_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             // Now the globals should be:
             // $flossie = 17
@@ -55,7 +55,7 @@ macro_rules! start_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            inst.run(b"main", &[]).expect("instance runs");
+            inst.run("main", &[]).expect("instance runs");
 
             // Now the globals should be:
             // $flossie = 17

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -45,7 +45,7 @@ macro_rules! strcmp_tests {
 
             let res = c_int::from(
                 inst.run(
-                    b"run_strcmp",
+                    "run_strcmp",
                     &[Val::GuestPtr(s1_ptr as u32), Val::GuestPtr(s2_ptr as u32)],
                 )
                 .expect("instance runs"),
@@ -84,7 +84,7 @@ macro_rules! strcmp_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
-            match inst.run(b"wasm_fault", &[]) {
+            match inst.run("wasm_fault", &[]) {
                 Err(Error::RuntimeFault { .. }) => (),
                 res => panic!("unexpected result: {:?}", res),
             }

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -165,9 +165,15 @@ pub unsafe extern "C" fn lucet_instance_run(
             .map(|v| v.into())
             .collect()
     };
+    let entrypoint = match CStr::from_ptr(entrypoint).to_str() {
+        Ok(entrypoint_str) => entrypoint_str,
+        Err(_) => {
+            return lucet_error::SymbolNotFound;
+        }
+    };
+
     with_instance_ptr!(inst, {
-        let entrypoint = CStr::from_ptr(entrypoint);
-        inst.run(entrypoint.to_bytes(), args.as_slice())
+        inst.run(entrypoint, args.as_slice())
             .map(|_| lucet_error::Ok)
             .unwrap_or_else(|e| {
                 eprintln!("{}", e);

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -53,7 +53,7 @@
 //! let region = MmapRegion::create(1, &Limits::default()).unwrap();
 //! let mut inst = region.new_instance(module).unwrap();
 //!
-//! let retval = inst.run(b"factorial", &[5u64.into()]).unwrap();
+//! let retval = inst.run("factorial", &[5u64.into()]).unwrap();
 //! assert_eq!(u64::from(retval), 120u64);
 //! ```
 //!
@@ -95,7 +95,7 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! inst.run(b"call_foo", &[]).unwrap();
+//! inst.run("call_foo", &[]).unwrap();
 //!
 //! let context_after = inst.get_embed_ctx::<MyContext>().unwrap().unwrap();
 //! assert_eq!(context_after.x, 42);
@@ -124,7 +124,7 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! inst.run(b"main", &[]).unwrap();
+//! inst.run("main", &[]).unwrap();
 //!
 //! // clean up embedder context
 //! drop(inst);
@@ -171,7 +171,7 @@
 //! // install the handler
 //! inst.set_signal_handler(signal_handler_count);
 //!
-//! match inst.run(b"raise_a_signal", &[]) {
+//! match inst.run("raise_a_signal", &[]) {
 //!     Err(Error::RuntimeFault(_)) => {
 //!         println!("I've now handled {} signals!", SIGNAL_COUNT.load(Ordering::SeqCst));
 //!     }

--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -159,7 +159,7 @@ impl ScriptEnv {
         args: Vec<Val>,
     ) -> Result<UntypedRetVal, ScriptError> {
         let (_, ref mut inst) = self.instance_named_mut(name)?;
-        inst.run(field.as_bytes(), &args)
+        inst.run(field, &args)
             .map_err(|e| ScriptError::RuntimeError(e))
     }
 

--- a/lucet-wasi-fuzz/src/main.rs
+++ b/lucet-wasi-fuzz/src/main.rs
@@ -382,7 +382,7 @@ fn run<P: AsRef<Path>>(
         .with_embed_ctx(ctx)
         .build()?;
 
-    match inst.run(b"_start", &[]) {
+    match inst.run("_start", &[]) {
         // normal termination implies 0 exit code
         Ok(_) => Ok(0),
         Err(lucet_runtime::Error::RuntimeTerminated(

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -188,7 +188,7 @@ fn run(config: Config) {
             .build()
             .expect("instance can be created");
 
-        match inst.run(config.entrypoint.as_bytes(), &[]) {
+        match inst.run(config.entrypoint, &[]) {
             // normal termination implies 0 exit code
             Ok(_) => 0,
             Err(lucet_runtime::Error::RuntimeTerminated(

--- a/lucet-wasi/tests/test_helpers/mod.rs
+++ b/lucet-wasi/tests/test_helpers/mod.rs
@@ -65,7 +65,7 @@ pub fn run<P: AsRef<Path>>(path: P, ctx: WasiCtx) -> Result<__wasi_exitcode_t, E
         .with_embed_ctx(ctx)
         .build()?;
 
-    match inst.run(b"_start", &[]) {
+    match inst.run("_start", &[]) {
         // normal termination implies 0 exit code
         Ok(_) => Ok(0),
         Err(lucet_runtime::Error::RuntimeTerminated(

--- a/lucetc/tests/wasi-sdk.rs
+++ b/lucetc/tests/wasi-sdk.rs
@@ -71,10 +71,11 @@ mod programs {
             0
         );
 
+        assert_eq!(mdata.import_functions().len(), 0, "import functions");
+        assert_eq!(mdata.export_functions().len(), 0, "export functions");
+
         /* FIXME: module data doesn't contain the information to check these properties:
-        assert_eq!(p.import_functions().len(), 0, "import functions");
         assert_eq!(num_import_globals(&p), 0, "import globals");
-        assert_eq!(num_export_functions(&p), 0, "export functions");
         */
 
         let _obj = c.object_file().expect("generate code from empty");
@@ -87,12 +88,13 @@ mod programs {
         let b = Bindings::empty();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile a");
-        let _mdata = c.module_data().unwrap();
+        let mdata = c.module_data().unwrap();
+
+        assert_eq!(mdata.import_functions().len(), 0, "import functions");
+        assert_eq!(mdata.export_functions().len(), 1, "export functions");
 
         /* FIXME: module data doesn't contain the information to check these properties:
-        assert_eq!(p.import_functions().len(), 0, "import functions");
         assert_eq!(num_import_globals(&p), 0, "import globals");
-        assert_eq!(num_export_functions(&p), 1, "export functions");
         */
 
         let _obj = c.object_file().expect("generate code from a");
@@ -104,11 +106,12 @@ mod programs {
         let b = b_only_test_bindings();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile b");
-        let _mdata = c.module_data().unwrap();
+        let mdata = c.module_data().unwrap();
+        assert_eq!(mdata.import_functions().len(), 1, "import functions");
+        assert_eq!(mdata.export_functions().len(), 1, "export functions");
+
         /* FIXME: module data doesn't contain the information to check these properties:
-        assert_eq!(p.import_functions().len(), 1, "import functions");
         assert_eq!(num_import_globals(&p), 0, "import globals");
-        assert_eq!(num_export_functions(&p), 1, "export functions");
         */
         let _obj = c.object_file().expect("generate code from b");
     }
@@ -119,11 +122,12 @@ mod programs {
         let b = Bindings::empty();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile a & b");
-        let _mdata = c.module_data().unwrap();
+        let mdata = c.module_data().unwrap();
+        assert_eq!(mdata.import_functions().len(), 0, "import functions");
+        assert_eq!(mdata.export_functions().len(), 2, "export functions");
+
         /* FIXME: module data doesn't contain the information to check these properties:
-        assert_eq!(p.import_functions().len(), 0, "import functions");
         assert_eq!(num_import_globals(&p), 0, "import globals");
-        assert_eq!(num_export_functions(&p), 2, "export functions");
         */
         let _obj = c.object_file().expect("generate code from a & b");
     }

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -46,7 +46,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.function_info().len(), 1);
-        assert_eq!(mdata.export_functions()[0].names, vec!["guest_func_main"]);
+        assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
 
     #[test]
@@ -60,7 +60,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.function_info().len(), 1);
-        assert_eq!(mdata.export_functions()[0].names, vec!["guest_func_main"]);
+        assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
     #[test]
     fn icall_import() {
@@ -77,10 +77,7 @@ mod module_data {
         assert_eq!(mdata.import_functions()[0].module, "env");
         assert_eq!(mdata.import_functions()[0].name, "icalltarget");
         assert_eq!(mdata.function_info().len(), 5);
-        assert_eq!(
-            mdata.export_functions()[0].names,
-            vec!["guest_func_launchpad"]
-        );
+        assert_eq!(mdata.export_functions()[0].names, vec!["launchpad"]);
         assert_eq!(mdata.globals_spec().len(), 0);
 
         /*  TODO can't express these with module data

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -46,7 +46,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.function_info().len(), 1);
-        assert_eq!(mdata.function_info()[0].sym, Some(&b"guest_func_main"[..]));
+        assert_eq!(mdata.export_functions()[0].names, vec!["guest_func_main"]);
     }
 
     #[test]
@@ -60,7 +60,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.function_info().len(), 1);
-        assert_eq!(mdata.function_info()[0].sym, Some(&b"guest_func_main"[..]));
+        assert_eq!(mdata.export_functions()[0].names, vec!["guest_func_main"]);
     }
     #[test]
     fn icall_import() {
@@ -75,14 +75,11 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 1);
         assert_eq!(mdata.import_functions()[0].module, "env");
-        assert_eq!(
-            mdata.sym_for(mdata.import_functions()[0].fn_idx),
-            Some(&b"icalltarget"[..])
-        );
+        assert_eq!(mdata.import_functions()[0].name, "icalltarget");
         assert_eq!(mdata.function_info().len(), 5);
         assert_eq!(
-            mdata.function_info()[1].sym,
-            Some(&b"guest_func_launchpad"[..])
+            mdata.export_functions()[0].names,
+            vec!["guest_func_launchpad"]
         );
         assert_eq!(mdata.globals_spec().len(), 0);
 

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -41,16 +41,12 @@ mod module_data {
         let b = super::test_bindings();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compiling fibonacci");
-        assert_eq!(c.module_data().unwrap().globals_spec().len(), 0);
+        let mdata = c.module_data().unwrap();
+        assert_eq!(mdata.globals_spec().len(), 0);
 
-        /* TODO can't express these with module data
-        assert_eq!(p.import_functions().len(), 0);
-        assert_eq!(p.defined_functions().len(), 1);
-        assert_eq!(
-            p.defined_functions().get(0).unwrap().symbol(),
-            "guest_func_main"
-        );
-        */
+        assert_eq!(mdata.import_functions().len(), 0);
+        assert_eq!(mdata.function_info().len(), 1);
+        assert_eq!(mdata.function_info()[0].sym, Some(&b"guest_func_main"[..]));
     }
 
     #[test]
@@ -59,16 +55,12 @@ mod module_data {
         let b = Bindings::empty();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compiling arith");
-        assert_eq!(c.module_data().unwrap().globals_spec().len(), 0);
+        let mdata = c.module_data().unwrap();
+        assert_eq!(mdata.globals_spec().len(), 0);
 
-        /* TODO can't express these with module data
-        assert_eq!(p.import_functions().len(), 0);
-        assert_eq!(p.defined_functions().len(), 1);
-        assert_eq!(
-            p.defined_functions().get(0).unwrap().symbol(),
-            "guest_func_main"
-        );
-        */
+        assert_eq!(mdata.import_functions().len(), 0);
+        assert_eq!(mdata.function_info().len(), 1);
+        assert_eq!(mdata.function_info()[0].sym, Some(&b"guest_func_main"[..]));
     }
     #[test]
     fn icall_import() {
@@ -79,18 +71,22 @@ mod module_data {
         .unwrap();
         let h = HeapSettings::default();
         let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile icall");
-        let _module_data = c.module_data().unwrap();
+        let mdata = c.module_data().unwrap();
+
+        assert_eq!(mdata.import_functions().len(), 1);
+        assert_eq!(mdata.import_functions()[0].module, "env");
+        assert_eq!(
+            mdata.sym_for(mdata.import_functions()[0].fn_idx),
+            Some(&b"icalltarget"[..])
+        );
+        assert_eq!(mdata.function_info().len(), 5);
+        assert_eq!(
+            mdata.function_info()[1].sym,
+            Some(&b"guest_func_launchpad"[..])
+        );
+        assert_eq!(mdata.globals_spec().len(), 0);
 
         /*  TODO can't express these with module data
-        assert_eq!(p.import_functions().len(), 1);
-        assert_eq!(p.import_functions()[0].module(), "env");
-        assert_eq!(p.import_functions()[0].field(), "icalltarget");
-        assert_eq!(p.globals().len(), 0);
-        assert_eq!(p.defined_functions().len(), 4);
-        assert_eq!(
-            p.defined_functions().get(0).unwrap().symbol(),
-            "guest_func_launchpad"
-        );
         assert_eq!(
             p.get_table(0).unwrap().elements().get(0),
             Some(&TableElem::FunctionIx(2))


### PR DESCRIPTION
also uncomment parts of lucetc tests that are now expressible/testable

Adds FunctionIndex newtype instead of passing around raw u32, to help make the lifecycle of function indices clearer.

Overall this isn't too big, but is the last piece I wanted to have in module data before renaming, and spending a moment fixing up lucet-analyze to know about all the new stuff.