### PR TITLE
Fix a path_get() bug with nested directories

### DIFF
--- a/lucet-wasi/src/hostcalls/fs_helpers.rs
+++ b/lucet-wasi/src/hostcalls/fs_helpers.rs
@@ -163,7 +163,7 @@ pub fn path_get<P: AsRef<OsStr>>(
                     || (component.ends_with(b"/") && !needs_final_component) =>
             {
                 match openat(
-                    *dir_stack.first().expect("dir_stack is never empty"),
+                    *dir_stack.last().expect("dir_stack is never empty"),
                     component,
                     OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
                     Mode::empty(),

--- a/lucet-wasi/tests/guests/fs.c
+++ b/lucet-wasi/tests/guests/fs.c
@@ -145,5 +145,14 @@ int main(void)
     res = closedir(dir);
     assert(res == 0);
 
+    res = mkdir("/sandbox/a", 0755);
+    assert(res == 0);
+    res = mkdir("/sandbox/a/b", 0755);
+    assert(res == 0);
+    res = mkdir("/sandbox/a/b/c", 0755);
+    assert(res == 0);
+    res = access("/sandbox/a/b/c", R_OK);
+    assert(res == 0);
+
     return 0;
 }


### PR DESCRIPTION
When traversing directories, we should keep the most recent file descriptor.

Add a test case originally triggering that bug.

Spotted by @kubkon -- thanks!