### PR TITLE
Rename lucetc optimization levels

### DIFF
--- a/benchmarks/lucet-benchmarks/src/compile.rs
+++ b/benchmarks/lucet-benchmarks/src/compile.rs
@@ -19,7 +19,7 @@ fn compile_hello_all(c: &mut Criterion) {
                 criterion::BatchSize::SmallInput,
             )
         },
-        &[OptLevel::Fastest, OptLevel::Default, OptLevel::Best],
+        &[OptLevel::None, OptLevel::Standard, OptLevel::Fast],
     )
     .sample_size(10);
 

--- a/benchmarks/lucet-benchmarks/src/par.rs
+++ b/benchmarks/lucet-benchmarks/src/par.rs
@@ -42,7 +42,7 @@ fn par_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Best);
+    compile_hello(&so_file, OptLevel::Fast);
 
     let module = DlModule::load(&so_file).unwrap();
 

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -29,7 +29,7 @@ fn hello_load_mkregion_and_instantiate<R: RegionCreate + 'static>(c: &mut Criter
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Best);
+    compile_hello(&so_file, OptLevel::Fast);
 
     c.bench_function(
         &format!("hello_load_mkregion_and_instantiate ({})", R::TYPE_NAME),
@@ -57,7 +57,7 @@ fn hello_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Best);
+    compile_hello(&so_file, OptLevel::Fast);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -125,7 +125,7 @@ fn hello_drop_instance<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Best);
+    compile_hello(&so_file, OptLevel::Fast);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -246,7 +246,7 @@ fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Best);
+    compile_hello(&so_file, OptLevel::Fast);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();

--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -67,7 +67,7 @@ impl ScriptEnv {
     }
     pub fn instantiate(&mut self, module: &[u8], name: &Option<String>) -> Result<(), ScriptError> {
         let bindings = bindings::spec_test_bindings();
-        let compiler = Compiler::new(module, OptLevel::Best, &bindings, HeapSettings::default())
+        let compiler = Compiler::new(module, OptLevel::Fast, &bindings, HeapSettings::default())
             .map_err(program_error)?;
 
         let dir = tempfile::Builder::new().prefix("codegen").tempdir()?;

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -23,23 +23,23 @@ use lucet_module_data::{FunctionSpec, ModuleData};
 
 #[derive(Debug, Clone, Copy)]
 pub enum OptLevel {
-    Default,
-    Best,
-    Fastest,
+    None,
+    Standard,
+    Fast,
 }
 
 impl Default for OptLevel {
     fn default() -> OptLevel {
-        OptLevel::Default
+        OptLevel::Standard
     }
 }
 
 impl OptLevel {
     pub fn to_flag(&self) -> &str {
         match self {
-            OptLevel::Default => "default",
-            OptLevel::Best => "best",
-            OptLevel::Fastest => "fastest",
+            OptLevel::None => "fast",
+            OptLevel::Standard => "default",
+            OptLevel::Fast => "best",
         }
     }
 }

--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -94,10 +94,10 @@ impl Options {
         };
 
         let opt_level = match m.value_of("opt_level") {
-            None => OptLevel::Default,
-            Some("default") => OptLevel::Default,
-            Some("best") => OptLevel::Best,
-            Some("fastest") => OptLevel::Fastest,
+            None => OptLevel::default(),
+            Some("0") => OptLevel::None,
+            Some("1") => OptLevel::Standard,
+            Some("2") => OptLevel::Fast,
             Some(_) => panic!("unknown value for opt-level"),
         };
 
@@ -195,8 +195,8 @@ impl Options {
                 Arg::with_name("opt_level")
                     .long("--opt-level")
                     .takes_value(true)
-                    .possible_values(&["default", "fastest", "best"])
-                    .help("optimization level (default: 'default')"),
+                    .possible_values(&["0", "1", "2"])
+                    .help("optimization level (default: '1')"),
             )
             .get_matches();
 

--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -97,7 +97,7 @@ impl Options {
             None => OptLevel::default(),
             Some("0") => OptLevel::None,
             Some("1") => OptLevel::Standard,
-            Some("2") => OptLevel::Fast,
+            Some("2") | Some("fast") => OptLevel::Fast,
             Some(_) => panic!("unknown value for opt-level"),
         };
 
@@ -195,7 +195,7 @@ impl Options {
                 Arg::with_name("opt_level")
                     .long("--opt-level")
                     .takes_value(true)
-                    .possible_values(&["0", "1", "2"])
+                    .possible_values(&["0", "1", "2", "fast"])
                     .help("optimization level (default: '1')"),
             )
             .get_matches();

--- a/lucetc/tests/wasi-sdk.rs
+++ b/lucetc/tests/wasi-sdk.rs
@@ -56,7 +56,7 @@ mod programs {
         let m = module_from_c(&["empty"], &[]).expect("build module for empty");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile empty");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile empty");
         let mdata = c.module_data().unwrap();
         assert!(mdata.heap_spec().is_some());
         // clang creates 3 globals, all internal:
@@ -87,7 +87,7 @@ mod programs {
 
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile a");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile a");
         let mdata = c.module_data().unwrap();
 
         assert_eq!(mdata.import_functions().len(), 0, "import functions");
@@ -105,7 +105,7 @@ mod programs {
         let m = module_from_c(&["b"], &["b"]).expect("build module for b");
         let b = b_only_test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile b");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile b");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.import_functions().len(), 1, "import functions");
         assert_eq!(mdata.export_functions().len(), 1, "export functions");
@@ -121,7 +121,7 @@ mod programs {
         let m = module_from_c(&["a", "b"], &["a", "b"]).expect("build module for a & b");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile a & b");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile a & b");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.import_functions().len(), 0, "import functions");
         assert_eq!(mdata.export_functions().len(), 2, "export functions");

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -40,7 +40,7 @@ mod module_data {
         let m = load_wat_module("fibonacci");
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compiling fibonacci");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compiling fibonacci");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -54,7 +54,7 @@ mod module_data {
         let m = load_wat_module("arith");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compiling arith");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compiling arith");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -70,7 +70,7 @@ mod module_data {
         ))
         .unwrap();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile icall");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile icall");
         let mdata = c.module_data().unwrap();
 
         assert_eq!(mdata.import_functions().len(), 1);
@@ -106,7 +106,7 @@ mod module_data {
         let m = load_wat_module("icall");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile icall");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile icall");
         let _module_data = c.module_data().unwrap();
 
         /*  TODO can't express these with module data
@@ -131,7 +131,7 @@ mod module_data {
         let m = load_wat_module("icall_sparse");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile icall_sparse");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile icall_sparse");
         let _module_data = c.module_data().unwrap();
 
         /*  TODO can't express these with module data
@@ -170,7 +170,7 @@ mod module_data {
         let b = Bindings::empty();
         let h = HeapSettings::default();
 
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile globals_import");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile globals_import");
         let module_data = c.module_data().unwrap();
         let gspec = module_data.globals_spec();
 
@@ -192,7 +192,7 @@ mod module_data {
         let b = Bindings::empty();
         let h = HeapSettings::default();
         let c =
-            Compiler::new(&m, OptLevel::Best, &b, h.clone()).expect("compiling heap_spec_import");
+            Compiler::new(&m, OptLevel::Fast, &b, h.clone()).expect("compiling heap_spec_import");
 
         assert_eq!(
             c.module_data().unwrap().heap_spec(),
@@ -214,7 +214,7 @@ mod module_data {
         let m = load_wat_module("heap_spec_definition");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h.clone())
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h.clone())
             .expect("compiling heap_spec_definition");
 
         assert_eq!(
@@ -236,7 +236,7 @@ mod module_data {
         let m = load_wat_module("heap_spec_none");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compiling heap_spec_none");
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compiling heap_spec_none");
         assert_eq!(c.module_data().unwrap().heap_spec(), None,);
     }
 
@@ -245,7 +245,7 @@ mod module_data {
         let m = load_wat_module("oversize_data_segment");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h);
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h);
         assert!(
             c.is_err(),
             "compilation error because data initializers are oversized"
@@ -268,7 +268,7 @@ mod module_data {
 
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h);
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h);
         assert!(
             c.is_err(),
             "compilation error because wasm module is invalid"
@@ -281,7 +281,7 @@ mod module_data {
         let m = load_wat_module("start_section");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let _c = Compiler::new(&m, OptLevel::Best, &b, h).expect("compile start_section");
+        let _c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile start_section");
         /*
         assert!(
             p.module().start_section().is_some(),
@@ -299,7 +299,7 @@ mod compile {
         let m = load_wat_module(file);
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Best, &b, h).expect(&format!("compile {}", file));
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect(&format!("compile {}", file));
         let _obj = c.object_file().expect(&format!("codegen {}", file));
     }
     macro_rules! compile_test {


### PR DESCRIPTION
Just call them `0`, `1` and `2` to avoid confusion, and `fast`, currently an alias for `2`.

Alternative names such as `size` can be added later.