### PR TITLE
Emit function information for lucetc-provided functions

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -132,40 +132,7 @@ impl<'a> Compiler<'a> {
                 .context(LucetcErrorKind::FunctionDefinition)?;
         }
 
-        use cranelift_entity::EntityRef;
-        stack_probe::declare_metadata(&mut self.decls.info).unwrap();
-        let stack_probe_id = self
-            .clif_module
-            .declare_function(
-                stack_probe::STACK_PROBE_SYM,
-                cranelift_module::Linkage::Local,
-                self.decls
-                    .info
-                    .signatures
-                    .get(
-                        *self
-                            .decls
-                            .info
-                            .signature_mapping
-                            .get(
-                                self.decls
-                                    .info
-                                    .functions
-                                    .get(cranelift_wasm::FuncIndex::new(
-                                        self.decls.info.functions.len() - 1,
-                                    ))
-                                    .unwrap()
-                                    .entity,
-                            )
-                            .unwrap(),
-                    )
-                    .unwrap(),
-            )
-            .unwrap();
-        self.decls.function_names.push(crate::name::Name::new_func(
-            stack_probe::STACK_PROBE_SYM.to_string(),
-            stack_probe_id,
-        ));
+        stack_probe::declare_metadata(&mut self.decls, &mut self.clif_module).unwrap();
 
         write_module_data(&mut self.clif_module, &self.decls)?;
         write_startfunc_data(&mut self.clif_module, &self.decls)?;

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -132,6 +132,41 @@ impl<'a> Compiler<'a> {
                 .context(LucetcErrorKind::FunctionDefinition)?;
         }
 
+        use cranelift_entity::EntityRef;
+        stack_probe::declare_metadata(&mut self.decls.info).unwrap();
+        let stack_probe_id = self
+            .clif_module
+            .declare_function(
+                stack_probe::STACK_PROBE_SYM,
+                cranelift_module::Linkage::Local,
+                self.decls
+                    .info
+                    .signatures
+                    .get(
+                        *self
+                            .decls
+                            .info
+                            .signature_mapping
+                            .get(
+                                self.decls
+                                    .info
+                                    .functions
+                                    .get(cranelift_wasm::FuncIndex::new(
+                                        self.decls.info.functions.len() - 1,
+                                    ))
+                                    .unwrap()
+                                    .entity,
+                            )
+                            .unwrap(),
+                    )
+                    .unwrap(),
+            )
+            .unwrap();
+        self.decls.function_names.push(crate::name::Name::new_func(
+            stack_probe::STACK_PROBE_SYM.to_string(),
+            stack_probe_id,
+        ));
+
         write_module_data(&mut self.clif_module, &self.decls)?;
         write_startfunc_data(&mut self.clif_module, &self.decls)?;
         write_table_data(&mut self.clif_module, &self.decls)?;

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -4,7 +4,6 @@ use crate::heap::HeapSettings;
 use crate::module::ModuleInfo;
 pub use crate::module::{Exportable, TableElems};
 use crate::name::Name;
-use crate::pointer::NATIVE_POINTER;
 use crate::runtime::{Runtime, RuntimeFunc};
 use cranelift_codegen::entity::{EntityRef, PrimaryMap};
 use cranelift_codegen::ir;
@@ -50,19 +49,8 @@ pub struct RuntimeDecl<'a> {
 }
 
 impl<'a> RuntimeDecl<'a> {
-    pub fn internal_signature(&self) -> &'a ir::Signature {
+    pub fn signature(&self) -> &'a ir::Signature {
         self.signature
-    }
-
-    pub fn native_signature(&self) -> ir::Signature {
-        let mut native_sig = self.signature.clone();
-
-        native_sig.params.insert(
-            0,
-            ir::AbiParam::special(NATIVE_POINTER, ir::ArgumentPurpose::VMContext),
-        );
-
-        native_sig
     }
 }
 

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -67,7 +67,7 @@ impl<'a> FuncInfo<'a> {
                     .module_decls
                     .get_runtime(runtime_func)
                     .expect("runtime function not available");
-                let signature = func.import_signature(decl.native_signature());
+                let signature = func.import_signature(decl.signature().to_owned());
                 let fref = func.import_function(ir::ExtFuncData {
                     name: decl.name.into(),
                     signature,

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -67,7 +67,7 @@ impl<'a> FuncInfo<'a> {
                     .module_decls
                     .get_runtime(runtime_func)
                     .expect("runtime function not available");
-                let signature = func.import_signature(decl.signature.clone());
+                let signature = func.import_signature(decl.native_signature());
                 let fref = func.import_function(ir::ExtFuncData {
                     name: decl.name.into(),
                     signature,

--- a/lucetc/src/module.rs
+++ b/lucetc/src/module.rs
@@ -99,6 +99,28 @@ impl<'a> ModuleInfo<'a> {
             data_initializers: HashMap::new(),
         }
     }
+
+    pub fn signature_for_function(&self, func_index: FuncIndex) -> &ir::Signature {
+        // FuncIndex are valid (or the caller has very bad data)
+        let sigidx = self.functions.get(func_index).unwrap().entity;
+
+        self.signature_by_id(sigidx)
+    }
+
+    pub fn signature_by_id(&self, sig_idx: SignatureIndex) -> &ir::Signature {
+        // All signatures map to some unique signature index
+        let unique_sig_idx = self.signature_mapping.get(sig_idx).unwrap();
+        // Unique signature indices are valid (or we're in some deeply bad state)
+        self.signatures.get(*unique_sig_idx).unwrap()
+    }
+
+    pub fn declare_func_with_sig(&mut self, sig: ir::Signature) -> (FuncIndex, SignatureIndex) {
+        let new_sigidx = SignatureIndex::from_u32(self.signature_mapping.len() as u32);
+        self.declare_signature(sig);
+        let new_funcidx = FuncIndex::from_u32(self.functions.len() as u32);
+        self.declare_func_type(new_sigidx);
+        (new_funcidx, new_sigidx)
+    }
 }
 
 impl<'a> ModuleEnvironment<'a> for ModuleInfo<'a> {

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -48,7 +48,7 @@ impl ObjectFile {
         stack_probe::declare_and_define(&mut product)?;
 
         // stack_probe::declare_and_define never exists as clif, and as a result never exist as
-        // compiled code. this means the declared length of the stack probe's code is 0. this is
+        // compiled code. This means the declared length of the stack probe's code is 0. This is
         // incorrect, and must be fixed up before writing out the function manifest.
 
         // because the stack probe is the last declared function...
@@ -57,6 +57,7 @@ impl ObjectFile {
             .get_mut(last_idx)
             .expect("function manifest has entries");
         debug_assert!(stack_probe_entry.0 == stack_probe::STACK_PROBE_SYM);
+        debug_assert!(stack_probe_entry.1.code_len() == 0);
         std::mem::swap(
             &mut stack_probe_entry.1,
             &mut FunctionSpec::new(

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -47,19 +47,6 @@ impl ObjectFile {
     ) -> Result<Self, Error> {
         stack_probe::declare_and_define(&mut product)?;
 
-        // stack_probe::declare_and_define adds a new function into `product`, but
-        // function_manifest was already constructed from all defined functions.
-        // So, we have to add a new entry to `function_manifest` for the stack probe
-        function_manifest.push((
-            stack_probe::STACK_PROBE_SYM.to_string(),
-            FunctionSpec::new(
-                0, // there is no real address for the function until written to an object file
-                stack_probe::STACK_PROBE_BINARY.len() as u32,
-                0,
-                0, // fix up this FunctionSpec with trap info like any other
-            ),
-        ));
-
         let trap_manifest = &product
             .trap_manifest
             .expect("trap manifest will be present");

--- a/lucetc/src/runtime.rs
+++ b/lucetc/src/runtime.rs
@@ -1,4 +1,4 @@
-use cranelift_codegen::ir::{types, AbiParam, ArgumentPurpose, Signature};
+use cranelift_codegen::ir::{types, AbiParam, Signature};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use std::collections::HashMap;
 
@@ -20,10 +20,7 @@ impl Runtime {
             (
                 "lucet_vmctx_current_memory".to_owned(),
                 Signature {
-                    params: vec![AbiParam::special(
-                        target.pointer_type(),
-                        ArgumentPurpose::VMContext,
-                    )],
+                    params: vec![],
                     returns: vec![AbiParam::new(types::I32)],
                     call_conv: target.default_call_conv,
                 },
@@ -35,7 +32,6 @@ impl Runtime {
                 "lucet_vmctx_grow_memory".to_owned(),
                 Signature {
                     params: vec![
-                        AbiParam::special(target.pointer_type(), ArgumentPurpose::VMContext),
                         AbiParam::new(types::I32), // wasm pages to grow
                     ],
                     returns: vec![AbiParam::new(types::I32)],

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -8,15 +8,15 @@
 //! adding custom entries for it into the trap table, so that stack overflows in the probe will be
 //! treated like any other guest trap.
 
-use crate::module::ModuleInfo;
+use crate::decls::ModuleDecls;
 use cranelift_codegen::binemit::TrapSink;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{types, AbiParam, Signature};
 use cranelift_codegen::isa::CallConv;
 use cranelift_faerie::traps::{FaerieTrapManifest, FaerieTrapSink};
 use cranelift_faerie::FaerieProduct;
-use cranelift_wasm::ModuleEnvironment;
-use cranelift_wasm::SignatureIndex;
+use cranelift_module::{Backend as ClifBackend, Linkage, Module as ClifModule};
+use cranelift_wasm::FuncIndex;
 use faerie::Decl;
 use failure::Error;
 
@@ -40,15 +40,23 @@ pub(crate) const STACK_PROBE_BINARY: &'static [u8] = &[
     0x29, 0xdc, 0x48, 0x85, 0x64, 0x24, 0x08, 0x48, 0x01, 0xc4, 0xc3,
 ];
 
-pub fn declare_metadata<'a>(info: &mut ModuleInfo<'a>) -> Result<(), Error> {
-    let runtime_sigidx = SignatureIndex::from_u32(info.signature_mapping.len() as u32);
-    info.declare_signature(Signature {
-        params: vec![],
-        returns: vec![AbiParam::new(types::I32)],
-        call_conv: CallConv::SystemV, // the stack probe function is very specific to x86_64, and possibly tos SystemV ABI platforms?
-    });
-    info.declare_func_type(runtime_sigidx);
-    Ok(())
+pub fn declare_metadata<'a, B: ClifBackend>(
+    decls: &mut ModuleDecls<'a>,
+    clif_module: &mut ClifModule<B>,
+) -> Result<FuncIndex, Error> {
+    // TODO: clean
+    Ok(decls
+        .declare_new_function(
+            clif_module,
+            STACK_PROBE_SYM.to_string(),
+            Linkage::Local,
+            Signature {
+                params: vec![],
+                returns: vec![AbiParam::new(types::I32)],
+                call_conv: CallConv::SystemV, // the stack probe function is very specific to x86_64, and possibly tos SystemV ABI platforms?
+            },
+        )
+        .unwrap())
 }
 
 pub fn declare_and_define(product: &mut FaerieProduct) -> Result<(), Error> {

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -44,7 +44,6 @@ pub fn declare_metadata<'a, B: ClifBackend>(
     decls: &mut ModuleDecls<'a>,
     clif_module: &mut ClifModule<B>,
 ) -> Result<FuncIndex, Error> {
-    // TODO: clean
     Ok(decls
         .declare_new_function(
             clif_module,
@@ -53,7 +52,7 @@ pub fn declare_metadata<'a, B: ClifBackend>(
             Signature {
                 params: vec![],
                 returns: vec![AbiParam::new(types::I32)],
-                call_conv: CallConv::SystemV, // the stack probe function is very specific to x86_64, and possibly tos SystemV ABI platforms?
+                call_conv: CallConv::SystemV, // the stack probe function is very specific to x86_64, and possibly to SystemV ABI platforms?
             },
         )
         .unwrap())

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -41,7 +41,7 @@ pub(crate) const STACK_PROBE_BINARY: &'static [u8] = &[
 ];
 
 pub fn declare_metadata<'a>(info: &mut ModuleInfo<'a>) -> Result<(), Error> {
-    let runtime_sigidx = SignatureIndex::from_u32(info.signatures.len() as u32);
+    let runtime_sigidx = SignatureIndex::from_u32(info.signature_mapping.len() as u32);
     info.declare_signature(Signature {
         params: vec![],
         returns: vec![AbiParam::new(types::I32)],

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -45,7 +45,7 @@ mod module_data {
         assert_eq!(mdata.globals_spec().len(), 0);
 
         assert_eq!(mdata.import_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 1);
+        assert_eq!(mdata.function_info().len(), 3);
         assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
 
@@ -59,7 +59,7 @@ mod module_data {
         assert_eq!(mdata.globals_spec().len(), 0);
 
         assert_eq!(mdata.import_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 1);
+        assert_eq!(mdata.function_info().len(), 3);
         assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
     #[test]
@@ -76,7 +76,7 @@ mod module_data {
         assert_eq!(mdata.import_functions().len(), 1);
         assert_eq!(mdata.import_functions()[0].module, "env");
         assert_eq!(mdata.import_functions()[0].name, "icalltarget");
-        assert_eq!(mdata.function_info().len(), 5);
+        assert_eq!(mdata.function_info().len(), 7);
         assert_eq!(mdata.export_functions()[0].names, vec!["launchpad"]);
         assert_eq!(mdata.globals_spec().len(), 0);
 


### PR DESCRIPTION
Runtime functions were not getting their supporting metadata (trap tables, names, ..) added to module data, which I think is mostly harmless, but violates some assumptions I'd made about what data is present in module data and function manifests. Specifically, that all functions in the module are present, and have a signature.