### PR TITLE
Fix benchmark entrypoint function signature

### DIFF
--- a/benchmarks/lucet-benchmarks/src/modules.rs
+++ b/benchmarks/lucet-benchmarks/src/modules.rs
@@ -1,4 +1,4 @@
-use lucet_module_data::FunctionPointer;
+use lucet_module_data::{lucet_signature, FunctionPointer};
 use lucet_runtime::lucet_hostcalls;
 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
 use lucet_runtime_internals::module::{HeapSpec, MockModuleBuilder, Module};
@@ -179,7 +179,24 @@ pub fn many_args_mock() -> Arc<dyn Module> {
     }
 
     MockModuleBuilder::new()
-        .with_export_func(MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize)))
+        .with_export_func(
+            MockExportBuilder::new("f", FunctionPointer::from_usize(f as usize))
+                .with_sig(lucet_signature!(
+                    (
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64,
+                        I32, I32, I32, I64, F32, F64
+                    ) -> ()
+                ))
+        )
         .build()
 }
 


### PR DESCRIPTION
well. _add_ an entrypoint function signature. The code compiles but when running `lucet-benchmark`, specifically "run_many_args", it fails because the mock module has the default signature of `() -> ()` where we provide ~66 arguments.