### PR TITLE
Improve the install target

### DIFF
--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -64,9 +64,9 @@ devenv_setenv_file="$(mktemp)"
 cat >"$devenv_setenv_file" <<EOT
 #! /bin/sh
 
-export PATH="${LUCET_BIN_DIR}:${PATH}"
-export LD_LIBRARY_PATH="${LUCET_LIB_DIR}:${LD_LIBRARY_PATH}"
-export DYLD_LIBRARY_PATH="${LUCET_LIB_DIR}:${DYLD_LIBRARY_PATH}"
+export PATH="${LUCET_BIN_DIR}:\${PATH}"
+export LD_LIBRARY_PATH="${LUCET_LIB_DIR}:\${LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="${LUCET_LIB_DIR}:\${DYLD_LIBRARY_PATH}"
 
 if [ \$# -gt 0 ]; then
     exec "\$@"


### PR DESCRIPTION
- When used interactively, give a chance to the user to change the destination directory, and provide feedback after installation
- Add support for macOS
- Exit early if directories cannot be created
- Suggest adding `${LUCET_BIN_DIR}/devenv_setenv.sh` to the shell configuration, with different instructions for the `fish` shell