### PR TITLE
Add support for small(er) Docker images to use (not work on) Lucet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 dist: xenial
 
 env:
-    - DEVENV_NO_INSTALL=1
+    - UNOPTIMIZED_BUILD=true
 
 services:
     - docker
 
 script:
     - ./devenv_run.sh make indent-check test audit
+    - ./devenv_stop.sh
     - git diff --exit-code
+    - ./devenv_build_toolchain_only.sh
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 dist: xenial
 
 env:
-  - DEVENV_NO_INSTALL=1
+    - DEVENV_NO_INSTALL=1
 
 services:
-  - docker
+    - docker
 
 script:
-  - ./devenv_run.sh make indent-check test audit
-  - git diff --exit-code
+    - ./devenv_run.sh make indent-check test audit
+    - git diff --exit-code
 
 notifications:
-  email: false
+    email: false

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -1,0 +1,14 @@
+FROM ubuntu:disco
+
+ENV WASI_SDK=/opt/wasi-sdk
+ENV LD_LIBRARY_PATH=/opt/lucet/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/lucet/bin:$PATH
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+	ca-certificates clang curl lld && \
+	rm -rf /var/lib/apt/lists/* && \
+	update-alternatives --install /usr/bin/wasm-ld wasm-ld /usr/bin/wasm-ld-8 100
+
+RUN curl -sL https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-5/libclang_rt.builtins-wasm32-wasi-5.0.tar.gz | tar x -zf - -C /usr/lib/llvm-8/lib/clang/8.0.0
+

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ build:
 install: build
 	@helpers/install.sh
 
+.PHONY: install-dev
+install-dev: build-dev
+	@helpers/install.sh --unoptimized
+
 .PHONY: test
 test: indent-check
 	cargo test --no-fail-fast \

--- a/devenv_build_container.sh
+++ b/devenv_build_container.sh
@@ -16,10 +16,7 @@ fi
 echo "Building lucet-dev:latest"
 docker build -t lucet-dev:latest .
 
-if [ -n "$DEVENV_NO_INSTALL" ]; then
-        docker tag lucet-dev:latest lucet:latest
-        exit
-fi
+docker tag lucet-dev:latest lucet:latest
 
 if docker image inspect lucet:latest > /dev/null; then
         if [ -z "$DEVENV_FORCE_REBUILD" ]; then
@@ -35,7 +32,11 @@ docker run --name=lucet-dev --detach --mount type=bind,src="$(cd $(dirname ${0})
         lucet-dev:latest /bin/sleep 99999999 > /dev/null
 
 echo "Building and installing optimized files in [$HOST_LUCET_MOUNT_POINT]"
-docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make install
+if [ -z "$UNOPTIMIZED_BUILD" ]; then
+        docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make install
+else
+        docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make install-dev
+fi
 
 echo "Cleaning"
 docker exec -t -w "$HOST_LUCET_MOUNT_POINT" lucet-dev make clean

--- a/devenv_build_container.sh
+++ b/devenv_build_container.sh
@@ -31,7 +31,7 @@ if docker image inspect lucet:latest > /dev/null; then
 fi
 
 echo "Now creating lucet:latest on top of lucet-dev:latest"
-docker run --name=lucet-dev --detach --mount type=bind,src="$(cd $(dirname ${0}); pwd -P),target=/lucet" \
+docker run --name=lucet-dev --detach --mount type=bind,src="$(cd $(dirname ${0}); pwd),target=/lucet" \
         lucet-dev:latest /bin/sleep 99999999 > /dev/null
 
 echo "Building and installing optimized files in [$HOST_LUCET_MOUNT_POINT]"

--- a/devenv_build_toolchain_only.sh
+++ b/devenv_build_toolchain_only.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+. "$(dirname ${BASH_SOURCE:-$0})/config.inc"
+
+git submodule update --init 2>/dev/null || :
+
+if ! docker image inspect lucet:latest >/dev/null; then
+        echo "A lucet image is not present"
+        exit 1
+fi
+
+echo "Building lucet-toolchain:latest"
+docker build -t lucet-toolchain:latest -f Dockerfile.toolchain .
+
+echo "Starting the lucet container"
+docker run --name=lucet --detach --mount type=bind,src="$(cd $(dirname ${0}); pwd),target=/lucet" \
+        lucet:latest /bin/sleep 99999999 > /dev/null
+
+echo "Creating a container from the lucet-toolchain:latest image"
+docker run --name=lucet-toolchain --detach --mount type=bind,src="$(
+        cd $(dirname ${0}) || exit 1
+        pwd -P
+),target=/lucet" \
+        lucet-toolchain:latest /bin/sleep 99999999 >/dev/null
+
+docker exec lucet tar c -pf - -C /opt lucet |
+        docker exec -i lucet-toolchain tar x -pf - -C /opt
+
+docker exec lucet-toolchain mkdir /opt/wasi-sysroot
+
+docker exec lucet tar c -pf - -C /opt/wasi-sdk/share/sysroot . |
+        docker exec -i lucet-toolchain tar x -pf - -C /opt/wasi-sysroot
+
+docker exec lucet-toolchain sh -c 'rm -f /opt/lucet/bin/wasm32-*'
+
+docker exec -i lucet-toolchain sh -c 'cat > /opt/lucet/bin/wasm32-wasi-clang; chmod 755 /opt/lucet/bin/wasm32-wasi-clang' <<EOT
+#! /bin/sh
+exec "clang" -fno-trapping-math -mthread-model single -W,--no-threads --target="wasm32-wasi" --sysroot="/opt/wasi-sysroot" "\$@"
+EOT
+
+docker exec -i lucet-toolchain sh -c 'cat > /opt/lucet/bin/wasm32-wasi-clang++; chmod 755 /opt/lucet/bin/wasm32-wasi-clang++' <<EOT
+#! /bin/sh
+exec "clang++" -fno-trapping-math -mthread-model single -W,--no-threads --target="wasm32-wasi" --sysroot="/opt/wasi-sysroot" "\$@"
+EOT
+
+docker container commit lucet-toolchain lucet-toolchain:latest &&
+        docker tag lucet-toolchain:latest fastly/lucet-toolchain:latest
+
+echo "Cleaning"
+docker kill lucet
+docker rm lucet
+docker kill lucet-toolchain
+docker rm lucet-toolchain
+
+echo "Done"

--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -9,9 +9,15 @@ if [ ! -x "${LUCET_SRC_PREFIX}/helpers/install.sh" ]; then
     exit 1
 fi
 
+if [ "$1" = "--unoptimized" ]; then
+    LUCET_BUILD_TYPE="debug"
+else
+    LUCET_BUILD_TYPE="release"
+fi
+
 LUCET_PREFIX=${LUCET_PREFIX:-"/opt/lucet"}
 LUCET_SRC_PREFIX=${LUCET_SRC_PREFIX:-"/lucet"}
-LUCET_SRC_RELEASE_DIR=${LUCET_SRC_RELEASE_DIR:-"${LUCET_SRC_PREFIX}/target/release"}
+LUCET_SRC_RELEASE_DIR=${LUCET_SRC_RELEASE_DIR:-"${LUCET_SRC_PREFIX}/target/${LUCET_BUILD_TYPE}"}
 LUCET_BIN_DIR=${LUCET_BIN_DIR:-"${LUCET_PREFIX}/bin"}
 LUCET_LIB_DIR=${LUCET_LIB_DIR:-"${LUCET_PREFIX}/lib"}
 LUCET_LIBEXEC_DIR=${LUCET_LIBEXEC_DIR:-"${LUCET_PREFIX}/libexec"}


### PR DESCRIPTION
This adds the ability to build a new Docker image, `lucet-toolchain`, that only contains the Lucet toolchain, and not the boilerplate to build it.

Lucet tools can then be directly used as:

```sh
docker run --rm lucet-toolchain lucet-wasi ...
```

This image is based on the current Ubuntu, and uses the stock LLVM installation, so it can be used as a base image for projects willing to build upon Lucet.