### PR TITLE
Float global support

### DIFF
--- a/lucet-analyze/src/main.rs
+++ b/lucet-analyze/src/main.rs
@@ -456,6 +456,19 @@ fn summarize_module_data<'a, 'b: 'a>(
     }
 
     println!("");
+    println!("Globals:");
+    if module_data.globals_spec().len() > 0 {
+        for global_spec in module_data.globals_spec().iter() {
+            println!("  {:?}", global_spec.global());
+            for name in global_spec.export_names() {
+                println!("    Exported as: {}", name);
+            }
+        }
+    } else {
+        println!("  None");
+    }
+
+    println!("");
     println!("Exported Functions/Symbols:");
     let mut exported_symbols = summary.exported_functions.clone();
     for export in module_data.export_functions() {

--- a/lucet-module-data/src/globals.rs
+++ b/lucet-module-data/src/globals.rs
@@ -9,36 +9,39 @@ use serde::{Deserialize, Serialize};
 pub struct GlobalSpec<'a> {
     #[serde(borrow)]
     global: Global<'a>,
-    export: Option<&'a str>,
+    export_names: Vec<&'a str>,
 }
 
 impl<'a> GlobalSpec<'a> {
-    pub fn new(global: Global<'a>, export: Option<&'a str>) -> Self {
-        Self { global, export }
+    pub fn new(global: Global<'a>, export_names: Vec<&'a str>) -> Self {
+        Self { global, export_names }
     }
 
-    /// Create a new global definition with an initial value and an optional export name.
-    pub fn new_def(init_val: i64, export: Option<&'a str>) -> Self {
+    /// Create a new global definition with an initial value and export names.
+    pub fn new_def(init_val: i64, export_names: Vec<&'a str>) -> Self {
         Self::new(
             Global::Def {
                 def: GlobalDef::new(init_val),
             },
-            export,
+            export_names,
         )
     }
 
-    /// Create a new global import definition with a module and field name, and an optional export
-    /// name.
-    pub fn new_import(module: &'a str, field: &'a str, export: Option<&'a str>) -> Self {
-        Self::new(Global::Import { module, field }, export)
+    /// Create a new global import definition with a module and field name, and export names.
+    pub fn new_import(module: &'a str, field: &'a str, export_names: Vec<&'a str>) -> Self {
+        Self::new(Global::Import { module, field }, export_names)
     }
 
     pub fn global(&self) -> &Global {
         &self.global
     }
 
-    pub fn export(&self) -> Option<&str> {
-        self.export
+    pub fn export_names(&self) -> &[&str] {
+        &self.export_names
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.export_names.len() == 0
     }
 }
 
@@ -83,38 +86,33 @@ impl GlobalDef {
 /// This type is useful when directly building up a value to be serialized.
 pub struct OwnedGlobalSpec {
     global: OwnedGlobal,
-    export: Option<String>,
+    export_names: Vec<String>,
 }
 
 impl OwnedGlobalSpec {
-    pub fn new(global: OwnedGlobal, export: Option<String>) -> Self {
-        Self { global, export }
+    pub fn new(global: OwnedGlobal, export_names: Vec<String>) -> Self {
+        Self { global, export_names }
     }
 
-    /// Create a new global definition with an initial value and an optional export name.
-    pub fn new_def(init_val: i64, export: Option<String>) -> Self {
+    /// Create a new global definition with an initial value and export names.
+    pub fn new_def(init_val: i64, export_names: Vec<String>) -> Self {
         Self::new(
             OwnedGlobal::Def {
                 def: GlobalDef::new(init_val),
             },
-            export,
+            export_names,
         )
     }
 
-    /// Create a new global import definition with a module and field name, and an optional export
-    /// name.
-    pub fn new_import(module: String, field: String, export: Option<String>) -> Self {
-        Self::new(OwnedGlobal::Import { module, field }, export)
+    /// Create a new global import definition with a module and field name, and export names.
+    pub fn new_import(module: String, field: String, export_names: Vec<String>) -> Self {
+        Self::new(OwnedGlobal::Import { module, field }, export_names)
     }
 
     /// Create a [`GlobalSpec`](../struct.GlobalSpec.html) backed by the values in this
     /// `OwnedGlobalSpec`.
     pub fn to_ref<'a>(&'a self) -> GlobalSpec<'a> {
-        let export = match &self.export {
-            Some(e) => Some(e.as_str()),
-            None => None,
-        };
-        GlobalSpec::new(self.global.to_ref(), export)
+        GlobalSpec::new(self.global.to_ref(), self.export_names.iter().map(|x| x.as_str()).collect())
     }
 }
 

--- a/lucet-module-data/src/globals.rs
+++ b/lucet-module-data/src/globals.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// The lifetime parameter exists to support zero-copy deserialization for the `&str` fields at the
 /// leaves of the structure. For a variant with owned types at the leaves, see
 /// [`OwnedGlobalSpec`](owned/struct.OwnedGlobalSpec.html).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GlobalSpec<'a> {
     #[serde(borrow)]
     global: Global<'a>,
@@ -20,9 +20,7 @@ impl<'a> GlobalSpec<'a> {
     /// Create a new global definition with an initial value and export names.
     pub fn new_def(init_val: i64, export_names: Vec<&'a str>) -> Self {
         Self::new(
-            Global::Def {
-                def: GlobalDef::new(init_val),
-            },
+            Global::Def(GlobalDef::I64(init_val)),
             export_names,
         )
     }
@@ -48,34 +46,61 @@ impl<'a> GlobalSpec<'a> {
 /// A WebAssembly global is either defined locally, or is defined in relation to a field of another
 /// WebAssembly module.
 ///
-/// Lucet currently does not support import globals, but we support the metadata for future
-/// compatibility.
-///
 /// The lifetime parameter exists to support zero-copy deserialization for the `&str` fields at the
 /// leaves of the structure. For a variant with owned types at the leaves, see
 /// [`OwnedGlobal`](owned/struct.OwnedGlobal.html).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Global<'a> {
-    Def { def: GlobalDef },
+    Def(GlobalDef),
     Import { module: &'a str, field: &'a str },
 }
 
-/// A global definition.
-///
-/// Currently we cast everything to an `i64`, but in the future this may have explicit variants for
-/// the different WebAssembly scalar types.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GlobalDef {
-    init_val: i64,
+/// Definition for a global in this module (not imported).
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GlobalDef {
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64)
 }
 
 impl GlobalDef {
-    pub fn new(init_val: i64) -> Self {
-        Self { init_val }
+    pub fn init_val(&self) -> GlobalValue {
+        match self {
+            GlobalDef::I32(i) => GlobalValue { i_32: *i },
+            GlobalDef::I64(i) => GlobalValue { i_64: *i },
+            GlobalDef::F32(f) => GlobalValue { f_32: *f },
+            GlobalDef::F64(f) => GlobalValue { f_64: *f },
+        }
     }
+}
 
-    pub fn init_val(&self) -> i64 {
-        self.init_val
+#[derive(Copy, Clone)]
+pub union GlobalValue {
+    pub i_32: i32,
+    pub i_64: i64,
+    pub f_32: f32,
+    pub f_64: f64,
+}
+
+impl std::fmt::Debug for GlobalValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Because GlobalValue is a union of primitives, there won't be anything wrong,
+        // representation-wise, with printing the underlying data as an i64, f64, or
+        // another primitive. This still may incur UB by doing something like trying to 
+        // read data from an uninitialized memory, if the union is initialized with a
+        // 32-bit value, and then read as a 64-bit value (as this code is about to do).
+        //
+        // In short, avoid using `<GlobalValue as Debug>`::fmt, please.
+
+        writeln!(f, "GlobalValue {{")?;
+        unsafe {
+            writeln!(f, "  i_32: {},", self.i_32)?;
+            writeln!(f, "  i_64: {},", self.i_64)?;
+            writeln!(f, "  f_32: {},", self.f_32)?;
+            writeln!(f, "  f_64: {},", self.f_64)?;
+        }
+        writeln!(f, "}}")
     }
 }
 
@@ -97,9 +122,7 @@ impl OwnedGlobalSpec {
     /// Create a new global definition with an initial value and export names.
     pub fn new_def(init_val: i64, export_names: Vec<String>) -> Self {
         Self::new(
-            OwnedGlobal::Def {
-                def: GlobalDef::new(init_val),
-            },
+            OwnedGlobal::Def(GlobalDef::I64(init_val)),
             export_names,
         )
     }
@@ -120,7 +143,7 @@ impl OwnedGlobalSpec {
 ///
 /// This type is useful when directly building up a value to be serialized.
 pub enum OwnedGlobal {
-    Def { def: GlobalDef },
+    Def(GlobalDef),
     Import { module: String, field: String },
 }
 
@@ -128,7 +151,7 @@ impl OwnedGlobal {
     /// Create a [`Global`](../struct.Global.html) backed by the values in this `OwnedGlobal`.
     pub fn to_ref<'a>(&'a self) -> Global<'a> {
         match self {
-            OwnedGlobal::Def { def } => Global::Def { def: def.clone() },
+            OwnedGlobal::Def(def) => Global::Def(def.clone()),
             OwnedGlobal::Import { module, field } => Global::Import {
                 module: module.as_str(),
                 field: field.as_str(),

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -12,7 +12,7 @@ mod traps;
 mod types;
 
 pub use crate::error::Error;
-pub use crate::globals::{Global, GlobalDef, GlobalSpec};
+pub use crate::globals::{Global, GlobalDef, GlobalSpec, GlobalValue};
 pub use crate::linear_memory::{HeapSpec, SparseData, LinearMemorySpec};
 pub use crate::module_data::ModuleData;
 pub use crate::functions::{ExportFunction, FunctionHandle, FunctionIndex, FunctionMetadata, FunctionPointer, FunctionSpec, ImportFunction, UniqueSignatureIndex};

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::module::Module;
 use crate::region::RegionInternal;
 use libc::{c_void, SIGSTKSZ};
+use lucet_module_data::GlobalValue;
 use nix::unistd::{sysconf, SysconfVar};
 use std::sync::{Arc, Once, Weak};
 
@@ -290,18 +291,18 @@ impl Alloc {
     }
 
     /// Return the globals as a slice.
-    pub unsafe fn globals(&self) -> &[i64] {
+    pub unsafe fn globals(&self) -> &[GlobalValue] {
         std::slice::from_raw_parts(
-            self.slot().globals as *const i64,
-            self.slot().limits.globals_size / 8,
+            self.slot().globals as *const GlobalValue,
+            self.slot().limits.globals_size / std::mem::size_of::<GlobalValue>(),
         )
     }
 
     /// Return the globals as a mutable slice.
-    pub unsafe fn globals_mut(&mut self) -> &mut [i64] {
+    pub unsafe fn globals_mut(&mut self) -> &mut [GlobalValue] {
         std::slice::from_raw_parts_mut(
-            self.slot().globals as *mut i64,
-            self.slot().limits.globals_size / 8,
+            self.slot().globals as *mut GlobalValue,
+            self.slot().limits.globals_size / std::mem::size_of::<GlobalValue>(),
         )
     }
 

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -2,7 +2,7 @@
 macro_rules! alloc_tests {
     ( $TestRegion:path ) => {
         use libc::c_void;
-        use lucet_module_data::FunctionPointer;
+        use lucet_module_data::{FunctionPointer, GlobalValue};
         use std::sync::Arc;
         use $TestRegion as TestRegion;
         use $crate::alloc::Limits;
@@ -349,15 +349,22 @@ macro_rules! alloc_tests {
                 assert_eq!(stack[LIMITS_STACK_SIZE - 1], 0xFF);
 
                 let globals = unsafe { inst.alloc_mut().globals_mut() };
-                assert_eq!(globals.len(), LIMITS_GLOBALS_SIZE / 8);
+                assert_eq!(
+                    globals.len(),
+                    LIMITS_GLOBALS_SIZE / std::mem::size_of::<GlobalValue>()
+                );
 
-                assert_eq!(globals[0], 0);
-                globals[0] = 0xFF;
-                assert_eq!(globals[0], 0xFF);
+                unsafe {
+                    assert_eq!(globals[0].i_64, 0);
+                    globals[0].i_64 = 0xFF;
+                    assert_eq!(globals[0].i_64, 0xFF);
+                }
 
-                assert_eq!(globals[globals.len() - 1], 0);
-                globals[globals.len() - 1] = 0xFF;
-                assert_eq!(globals[globals.len() - 1], 0xFF);
+                unsafe {
+                    assert_eq!(globals[globals.len() - 1].i_64, 0);
+                    globals[globals.len() - 1].i_64 = 0xFF;
+                    assert_eq!(globals[globals.len() - 1].i_64, 0xFF);
+                }
 
                 let sigstack = unsafe { inst.alloc_mut().sigstack_mut() };
                 assert_eq!(sigstack.len(), libc::SIGSTKSZ);

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -14,7 +14,7 @@ use crate::sysdeps::UContext;
 use crate::val::{UntypedRetVal, Val};
 use crate::WASM_PAGE_SIZE;
 use libc::{c_void, siginfo_t, uintptr_t, SIGBUS, SIGSEGV};
-use lucet_module_data::{FunctionHandle, FunctionPointer, TrapCode};
+use lucet_module_data::{FunctionHandle, FunctionPointer, GlobalValue, TrapCode};
 use memoffset::offset_of;
 use std::any::Any;
 use std::cell::{BorrowError, BorrowMutError, Ref, RefCell, RefMut, UnsafeCell};
@@ -354,7 +354,7 @@ impl Instance {
                         i
                     )));
                 }
-                Global::Def { def } => def.init_val(),
+                Global::Def(def) => def.init_val(),
             };
         }
 
@@ -404,12 +404,12 @@ impl Instance {
     }
 
     /// Return the WebAssembly globals as a slice of `i64`s.
-    pub fn globals(&self) -> &[i64] {
+    pub fn globals(&self) -> &[GlobalValue] {
         unsafe { self.alloc.globals() }
     }
 
     /// Return the WebAssembly globals as a mutable slice of `i64`s.
-    pub fn globals_mut(&mut self) -> &mut [i64] {
+    pub fn globals_mut(&mut self) -> &mut [GlobalValue] {
         unsafe { self.alloc.globals_mut() }
     }
 

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -64,14 +64,14 @@ impl MockModuleBuilder {
 
     pub fn with_global(mut self, idx: u32, init_val: i64) -> Self {
         self.globals
-            .insert(idx as usize, OwnedGlobalSpec::new_def(init_val, None));
+            .insert(idx as usize, OwnedGlobalSpec::new_def(init_val, vec![]));
         self
     }
 
     pub fn with_exported_global(mut self, idx: u32, init_val: i64, export_name: &str) -> Self {
         self.globals.insert(
             idx as usize,
-            OwnedGlobalSpec::new_def(init_val, Some(export_name.to_string())),
+            OwnedGlobalSpec::new_def(init_val, vec![export_name.to_string()]),
         );
         self
     }
@@ -79,7 +79,7 @@ impl MockModuleBuilder {
     pub fn with_import(mut self, idx: u32, import_module: &str, import_field: &str) -> Self {
         self.globals.insert(
             idx as usize,
-            OwnedGlobalSpec::new_import(import_module.to_string(), import_field.to_string(), None),
+            OwnedGlobalSpec::new_import(import_module.to_string(), import_field.to_string(), vec![]),
         );
         self
     }
@@ -96,7 +96,7 @@ impl MockModuleBuilder {
             OwnedGlobalSpec::new_import(
                 import_module.to_string(),
                 import_field.to_string(),
-                Some(export_name.to_string()),
+                vec![export_name.to_string()],
             ),
         );
         self

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -79,7 +79,11 @@ impl MockModuleBuilder {
     pub fn with_import(mut self, idx: u32, import_module: &str, import_field: &str) -> Self {
         self.globals.insert(
             idx as usize,
-            OwnedGlobalSpec::new_import(import_module.to_string(), import_field.to_string(), vec![]),
+            OwnedGlobalSpec::new_import(
+                import_module.to_string(),
+                import_field.to_string(),
+                vec![],
+            ),
         );
         self
     }

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -11,7 +11,7 @@ use crate::error::Error;
 use crate::instance::{
     Instance, InstanceInternal, State, TerminationDetails, CURRENT_INSTANCE, HOST_CTX,
 };
-use lucet_module_data::FunctionHandle;
+use lucet_module_data::{FunctionHandle, GlobalValue};
 use std::any::Any;
 use std::borrow::{Borrow, BorrowMut};
 use std::cell::{Ref, RefCell, RefMut};
@@ -31,7 +31,7 @@ pub struct Vmctx {
     /// This must never be dropped automatically, as the view does not own the globals. Rather, this
     /// is a value used to implement dynamic borrowing of the globals that are owned and managed by
     /// the instance and its `Alloc`.
-    globals_view: RefCell<Box<[i64]>>,
+    globals_view: RefCell<Box<[GlobalValue]>>,
 }
 
 impl Drop for Vmctx {
@@ -82,7 +82,7 @@ impl Vmctx {
         let res = Vmctx {
             vmctx,
             heap_view: RefCell::new(Box::<[u8]>::from_raw(inst.heap_mut())),
-            globals_view: RefCell::new(Box::<[i64]>::from_raw(inst.globals_mut())),
+            globals_view: RefCell::new(Box::<[GlobalValue]>::from_raw(inst.globals_mut())),
         };
         res
     }
@@ -205,7 +205,7 @@ impl Vmctx {
     ///
     /// If the globals are already mutably borrowed by `globals_mut()`, the instance will terminate
     /// with `TerminationDetails::BorrowError`.
-    pub fn globals(&self) -> Ref<[i64]> {
+    pub fn globals(&self) -> Ref<[GlobalValue]> {
         let r = self
             .globals_view
             .try_borrow()
@@ -217,7 +217,7 @@ impl Vmctx {
     ///
     /// If the globals are already borrowed by `globals()` or `globals_mut()`, the instance will
     /// terminate with `TerminationDetails::BorrowError`.
-    pub fn globals_mut(&self) -> RefMut<[i64]> {
+    pub fn globals_mut(&self) -> RefMut<[GlobalValue]> {
         let r = self
             .globals_view
             .try_borrow_mut()

--- a/lucet-runtime/lucet-runtime-tests/src/globals.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/globals.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! globals_tests {
     ( $TestRegion:path ) => {
-        use lucet_module_data::{lucet_signature, FunctionPointer};
+        use lucet_module_data::{lucet_signature, FunctionPointer, GlobalValue};
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{Error, Limits, Module, Region};
         use std::sync::Arc;
@@ -62,22 +62,22 @@ macro_rules! globals_tests {
 
         fn mock_globals_module() -> Arc<dyn Module> {
             extern "C" {
-                fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut i64;
+                fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut GlobalValue;
             }
 
             unsafe extern "C" fn get_global0(vmctx: *mut lucet_vmctx) -> i64 {
                 let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
-                globals[0]
+                globals[0].i_64
             }
 
             unsafe extern "C" fn set_global0(vmctx: *mut lucet_vmctx, val: i64) {
                 let globals = std::slice::from_raw_parts_mut(lucet_vmctx_get_globals(vmctx), 2);
-                globals[0] = val;
+                globals[0].i_64 = val;
             }
 
             unsafe extern "C" fn get_global1(vmctx: *mut lucet_vmctx) -> i64 {
                 let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
-                globals[1]
+                globals[1].i_64
             }
 
             MockModuleBuilder::new()
@@ -109,8 +109,8 @@ macro_rules! globals_tests {
             let inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-            assert_eq!(inst.globals()[0], -1);
-            assert_eq!(inst.globals()[1], 420);
+            assert_eq!(unsafe { inst.globals()[0].i_64 }, -1);
+            assert_eq!(unsafe { inst.globals()[1].i_64 }, 420);
         }
 
         #[test]

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -267,25 +267,42 @@ impl<'a> ModuleDecls<'a> {
         for ix in 0..info.globals.len() {
             let ix = GlobalIndex::new(ix);
             let g_decl = info.globals.get(ix).unwrap();
-            let g_import = info.imported_globals.get(ix);
-            let g_variant = if let Some((module, field)) = g_import {
-                GlobalVariant::Import { module, field }
-            } else {
-                let init_val = match g_decl.entity.initializer {
-                    // Need to fix global spec in ModuleData and the runtime to support more:
-                    GlobalInit::I32Const(i) => i as i64,
-                    GlobalInit::I64Const(i) => i,
-                    _ => Err(format_err!(
-                        "non-integer global initializer: {:?}",
-                        g_decl.entity
-                    ))
-                    .context(LucetcErrorKind::Unsupported)?,
-                };
-                GlobalVariant::Def {
-                    def: GlobalDef::new(init_val),
+
+            let global = match g_decl.entity.initializer {
+                GlobalInit::I32Const(i) => Ok(GlobalVariant::Def(GlobalDef::I32(i))),
+                GlobalInit::I64Const(i) => Ok(GlobalVariant::Def(GlobalDef::I64(i))),
+                GlobalInit::F32Const(f) => {
+                    Ok(GlobalVariant::Def(GlobalDef::F32(f32::from_bits(f))))
                 }
-            };
-            globals.push(GlobalSpec::new(g_variant, g_decl.export_names.clone()));
+                GlobalInit::F64Const(f) => {
+                    Ok(GlobalVariant::Def(GlobalDef::F64(f64::from_bits(f))))
+                }
+                GlobalInit::GetGlobal(ref_ix) => {
+                    let ref_decl = info.globals.get(ref_ix).unwrap();
+                    if let GlobalInit::Import = ref_decl.entity.initializer {
+                        if let Some((module, field)) = info.imported_globals.get(ref_ix) {
+                            Ok(GlobalVariant::Import { module, field })
+                        } else {
+                            Err(format_err!("inconsistent state: global {} is declared as an import but has no entry in imported_globals", ref_ix.as_u32()))
+                            .context(LucetcErrorKind::TranslatingModule)
+                        }
+                    } else {
+                        // This WASM restriction may be loosened in the future:
+                        Err(format_err!("invalid global declarations: global {} is initialized by referencing another global value, but the referenced global is not an import", ix.as_u32()))
+                        .context(LucetcErrorKind::TranslatingModule)
+                    }
+                }
+                GlobalInit::Import => {
+                    if let Some((module, field)) = info.imported_globals.get(ix) {
+                        Ok(GlobalVariant::Import { module, field })
+                    } else {
+                        Err(format_err!("inconsistent state: global {} is declared as an import but has no entry in imported_globals", ix.as_u32()))
+                        .context(LucetcErrorKind::TranslatingModule)
+                    }
+                }
+            }?;
+
+            globals.push(GlobalSpec::new(global, g_decl.export_names.clone()));
         }
         Ok(globals)
     }

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -285,7 +285,7 @@ impl<'a> ModuleDecls<'a> {
                     def: GlobalDef::new(init_val),
                 }
             };
-            globals.push(GlobalSpec::new(g_variant, None));
+            globals.push(GlobalSpec::new(g_variant, g_decl.export_names.clone()));
         }
         Ok(globals)
     }

--- a/lucetc/tests/wasi-sdk.rs
+++ b/lucetc/tests/wasi-sdk.rs
@@ -59,17 +59,11 @@ mod programs {
         let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compile empty");
         let mdata = c.module_data().unwrap();
         assert!(mdata.heap_spec().is_some());
-        // clang creates 3 globals, all internal:
+        // clang creates 3 globals:
         assert_eq!(mdata.globals_spec().len(), 3);
-        assert_eq!(
-            mdata
-                .globals_spec()
-                .iter()
-                .filter(|g| g.export().is_some())
-                .collect::<Vec<_>>()
-                .len(),
-            0
-        );
+        assert!(mdata.globals_spec()[0].is_internal());
+        assert_eq!(mdata.globals_spec()[1].export_names(), &["__heap_base"]);
+        assert_eq!(mdata.globals_spec()[2].export_names(), &["__data_end"]);
 
         assert_eq!(mdata.import_functions().len(), 0, "import functions");
         assert_eq!(mdata.export_functions().len(), 0, "export functions");

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -36,6 +36,22 @@ mod module_data {
     use std::path::PathBuf;
 
     #[test]
+    fn globals_export() {
+        let m = load_wat_module("globals_export");
+        let b = super::test_bindings();
+        let h = HeapSettings::default();
+        let c = Compiler::new(&m, OptLevel::Fast, &b, h).expect("compiling globals_export");
+        let mdata = c.module_data().unwrap();
+
+        assert_eq!(mdata.globals_spec().len(), 1);
+        assert_eq!(mdata.globals_spec()[0].export_names(), &["start", "dupe"]);
+
+        assert_eq!(mdata.import_functions().len(), 0);
+        assert_eq!(mdata.export_functions().len(), 0);
+        assert_eq!(mdata.function_info().len(), 2);
+    }
+
+    #[test]
     fn fibonacci() {
         let m = load_wat_module("fibonacci");
         let b = super::test_bindings();

--- a/lucetc/tests/wasm/globals_export.wat
+++ b/lucetc/tests/wasm/globals_export.wat
@@ -1,0 +1,5 @@
+(module
+  (global (;0;) i32 (i32.const 0x1234))
+  (export "start" (global 0))
+  (export "dupe" (global 0))
+)


### PR DESCRIPTION
Split from #196 into changes I'd be comfortable squashing together:

This adjusts globals to allow for a global exported by multiple names, and adds support for globals of type `f32` and `f64`. This is sufficient to get us spec-compliant for globals!

I noticed `lucet-analyze` was missing information about globals, so I added that as well.

This makes global values a union and adds some unsafe as a consequence, but my understanding is that type confusion of globals would requite wasm that doesn't validate, so this "only" would require additional unsafe code on the embedder's side. Since I imagine it's relatively unlikely to be prodding an instance's globals outside initialization, that seems acceptable vs the additional implementation complexity of separating out globals by type.