### PR TITLE
WASI fixes

### DIFF
--- a/lucet-wasi/src/hostcalls/fs.rs
+++ b/lucet-wasi/src/hostcalls/fs.rs
@@ -60,12 +60,8 @@ pub fn wasi_fd_fdstat_get(
     } else {
         wasm32::__WASI_EBADF
     };
-
-    unsafe {
-        enc_fdstat_byref(vmctx, fdstat_ptr, host_fdstat)
-            .expect("can write back into the pointer we read from");
-    }
-
+    enc_fdstat_byref(vmctx, fdstat_ptr, host_fdstat)
+        .expect("can write back into the pointer we read from");
     errno
 }
 
@@ -109,12 +105,9 @@ pub fn wasi_fd_tell(
             Err(e) => return enc_errno(e),
         }
     };
-
-    unsafe {
-        enc_filesize_byref(vmctx, offset, host_offset as u64)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_filesize_byref(vmctx, offset, host_offset as u64)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_seek(
@@ -151,12 +144,9 @@ pub fn wasi_fd_seek(
             Err(e) => return enc_errno(e),
         }
     };
-
-    unsafe {
-        enc_filesize_byref(vmctx, newoffset, host_newoffset as u64)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_filesize_byref(vmctx, newoffset, host_newoffset as u64)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_prestat_get(
@@ -174,23 +164,20 @@ pub fn wasi_fd_prestat_get(
                 if fe.fd_object.ty != host::__WASI_FILETYPE_DIRECTORY as host::__wasi_filetype_t {
                     return wasm32::__WASI_ENOTDIR;
                 }
-                unsafe {
-                    enc_prestat_byref(
-                        vmctx,
-                        prestat_ptr,
-                        host::__wasi_prestat_t {
-                            pr_type: host::__WASI_PREOPENTYPE_DIR as host::__wasi_preopentype_t,
-                            u: host::__wasi_prestat_t___wasi_prestat_u {
-                                dir:
-                                    host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
-                                        pr_name_len: po_path.as_os_str().as_bytes().len(),
-                                    },
+                enc_prestat_byref(
+                    vmctx,
+                    prestat_ptr,
+                    host::__wasi_prestat_t {
+                        pr_type: host::__WASI_PREOPENTYPE_DIR as host::__wasi_preopentype_t,
+                        u: host::__wasi_prestat_t___wasi_prestat_u {
+                            dir: host::__wasi_prestat_t___wasi_prestat_u___wasi_prestat_u_dir_t {
+                                pr_name_len: po_path.as_os_str().as_bytes().len(),
                             },
                         },
-                    )
-                    .map(|_| wasm32::__WASI_ESUCCESS)
-                    .unwrap_or_else(|e| e)
-                }
+                    },
+                )
+                .map(|_| wasm32::__WASI_ESUCCESS)
+                .unwrap_or_else(|e| e)
             } else {
                 wasm32::__WASI_ENOTSUP
             }
@@ -218,11 +205,9 @@ pub fn wasi_fd_prestat_dir_name(
                 if path_bytes.len() > dec_usize(path_len) {
                     return wasm32::__WASI_ENAMETOOLONG;
                 }
-                unsafe {
-                    enc_slice_of(vmctx, path_bytes, path_ptr)
-                        .map(|_| wasm32::__WASI_ESUCCESS)
-                        .unwrap_or_else(|e| e)
-                }
+                enc_slice_of(vmctx, path_bytes, path_ptr)
+                    .map(|_| wasm32::__WASI_ESUCCESS)
+                    .unwrap_or_else(|e| e)
             } else {
                 wasm32::__WASI_ENOTSUP
             }
@@ -268,12 +253,9 @@ pub fn wasi_fd_read(
         let mut fe = ctx.fds.remove(&fd).expect("file entry is still there");
         fe.fd_object.needs_close = false;
     }
-
-    unsafe {
-        enc_usize_byref(vmctx, nread, host_nread)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_usize_byref(vmctx, nread, host_nread)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_write(
@@ -307,12 +289,9 @@ pub fn wasi_fd_write(
         Ok(len) => len,
         Err(e) => return wasm32::errno_from_nix(e.as_errno().unwrap()),
     };
-
-    unsafe {
-        enc_usize_byref(vmctx, nwritten, host_nwritten)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_usize_byref(vmctx, nwritten, host_nwritten)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_path_open(
@@ -459,6 +438,9 @@ pub fn wasi_path_open(
             nix::unistd::close(new_fd).unwrap_or_else(|e| {
                 dbg!(e);
             });
+            if let Err(e) = enc_fd_byref(vmctx, fd_out_ptr, wasm32::__wasi_fd_t::max_value()) {
+                return enc_errno(e);
+            }
             return enc_errno(e);
         }
         Ok((_ty, max_base, max_inheriting)) => {
@@ -471,12 +453,9 @@ pub fn wasi_path_open(
             }
         }
     };
-
-    unsafe {
-        enc_fd_byref(vmctx, fd_out_ptr, guest_fd)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_fd_byref(vmctx, fd_out_ptr, guest_fd)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_filestat_get(
@@ -495,10 +474,8 @@ pub fn wasi_fd_filestat_get(
             Err(e) => return wasm32::errno_from_nix(e.as_errno().unwrap()),
             Ok(filestat) => {
                 let host_filestat = host::filestat_from_nix(filestat);
-                unsafe {
-                    enc_filestat_byref(vmctx, filestat_ptr, host_filestat)
-                        .expect("can write into the pointer");
-                }
+                enc_filestat_byref(vmctx, filestat_ptr, host_filestat)
+                    .expect("can write into the pointer");
             }
         },
         Err(e) => return enc_errno(e),
@@ -536,10 +513,8 @@ pub fn wasi_path_filestat_get(
         Err(e) => wasm32::errno_from_nix(e.as_errno().unwrap()),
         Ok(filestat) => {
             let host_filestat = host::filestat_from_nix(filestat);
-            unsafe {
-                enc_filestat_byref(vmctx, filestat_ptr, host_filestat)
-                    .expect("can write into the pointer");
-            }
+            enc_filestat_byref(vmctx, filestat_ptr, host_filestat)
+                .expect("can write into the pointer");
             wasm32::__WASI_ESUCCESS
         }
     }
@@ -601,7 +576,26 @@ pub fn wasi_path_unlink_file(
     // nix doesn't expose unlinkat() yet
     match unsafe { unlinkat(dir, path_cstr.as_ptr(), 0) } {
         0 => wasm32::__WASI_ESUCCESS,
-        _ => wasm32::errno_from_nix(errno::Errno::last()),
+        _ => {
+            let mut e = errno::Errno::last();
+            // Non-Linux implementations may return EPERM when attempting to remove a
+            // directory without `REMOVEDIR`. For WASI, adjust this to `EISDIR`.
+            #[cfg(not(linux))]
+            {
+                use nix::fcntl::AtFlags;
+                use nix::sys::stat::{fstatat, SFlag};
+                if e == errno::Errno::EPERM {
+                    if let Ok(stat) = fstatat(dir, path.as_os_str(), AtFlags::AT_SYMLINK_NOFOLLOW) {
+                        if SFlag::from_bits_truncate(stat.st_mode).contains(SFlag::S_IFDIR) {
+                            e = errno::Errno::EISDIR;
+                        }
+                    } else {
+                        e = errno::Errno::last();
+                    }
+                }
+            }
+            wasm32::errno_from_nix(e)
+        }
     }
 }
 
@@ -977,11 +971,9 @@ pub fn wasi_fd_pread(
         buf_offset += vec_len;
         left -= vec_len;
     }
-    unsafe {
-        enc_usize_byref(vmctx, nread, host_nread)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_usize_byref(vmctx, nread, host_nread)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_pwrite(
@@ -1020,11 +1012,9 @@ pub fn wasi_fd_pwrite(
         Ok(len) => len,
         Err(e) => return wasm32::errno_from_nix(e.as_errno().unwrap()),
     };
-    unsafe {
-        enc_usize_byref(vmctx, nwritten, host_nwritten)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_usize_byref(vmctx, nwritten, host_nwritten)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_readdir(
@@ -1101,11 +1091,9 @@ pub fn wasi_fd_readdir(
         left -= required_space;
     }
     let host_bufused = host_buf_len - left;
-    unsafe {
-        enc_usize_byref(vmctx, bufused, host_bufused)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_usize_byref(vmctx, bufused, host_bufused)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_fd_renumber(

--- a/lucet-wasi/src/hostcalls/misc.rs
+++ b/lucet-wasi/src/hostcalls/misc.rs
@@ -61,7 +61,7 @@ pub fn wasi_args_get(
         let arg_bytes = arg.as_bytes_with_nul();
         let arg_ptr = argv_buf + argv_buf_offset;
 
-        if let Err(e) = unsafe { enc_slice_of(vmctx, arg_bytes, arg_ptr) } {
+        if let Err(e) = enc_slice_of(vmctx, arg_bytes, arg_ptr) {
             return enc_errno(e);
         }
 
@@ -76,12 +76,9 @@ pub fn wasi_args_get(
             return wasm32::__WASI_EOVERFLOW;
         }
     }
-
-    unsafe {
-        enc_slice_of(vmctx, argv.as_slice(), argv_ptr)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_slice_of(vmctx, argv.as_slice(), argv_ptr)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_args_sizes_get(
@@ -97,14 +94,11 @@ pub fn wasi_args_sizes_get(
         .iter()
         .map(|arg| arg.as_bytes_with_nul().len())
         .sum();
-
-    unsafe {
-        if let Err(e) = enc_usize_byref(vmctx, argc_ptr, argc) {
-            return enc_errno(e);
-        }
-        if let Err(e) = enc_usize_byref(vmctx, argv_buf_size_ptr, argv_size) {
-            return enc_errno(e);
-        }
+    if let Err(e) = enc_usize_byref(vmctx, argc_ptr, argc) {
+        return enc_errno(e);
+    }
+    if let Err(e) = enc_usize_byref(vmctx, argv_buf_size_ptr, argv_size) {
+        return enc_errno(e);
     }
     wasm32::__WASI_ESUCCESS
 }
@@ -146,11 +140,9 @@ pub fn wasi_clock_res_get(
             if resolution == 0 {
                 wasm32::__WASI_EINVAL
             } else {
-                unsafe {
-                    enc_timestamp_byref(vmctx, resolution_ptr, resolution)
-                        .map(|_| wasm32::__WASI_ESUCCESS)
-                        .unwrap_or_else(|e| e)
-                }
+                enc_timestamp_byref(vmctx, resolution_ptr, resolution)
+                    .map(|_| wasm32::__WASI_ESUCCESS)
+                    .unwrap_or_else(|e| e)
             }
         })
         .unwrap_or(wasm32::__WASI_EOVERFLOW)
@@ -185,7 +177,7 @@ pub fn wasi_clock_time_get(
     (timespec.tv_sec as host::__wasi_timestamp_t)
         .checked_mul(1_000_000_000)
         .and_then(|sec_ns| sec_ns.checked_add(timespec.tv_nsec as host::__wasi_timestamp_t))
-        .map(|time| unsafe {
+        .map(|time| {
             enc_timestamp_byref(vmctx, time_ptr, time)
                 .map(|_| wasm32::__WASI_ESUCCESS)
                 .unwrap_or_else(|e| e)
@@ -207,7 +199,7 @@ pub fn wasi_environ_get(
         let env_bytes = pair.as_bytes_with_nul();
         let env_ptr = environ_buf + environ_buf_offset;
 
-        if let Err(e) = unsafe { enc_slice_of(vmctx, env_bytes, env_ptr) } {
+        if let Err(e) = enc_slice_of(vmctx, env_bytes, env_ptr) {
             return enc_errno(e);
         }
 
@@ -222,12 +214,9 @@ pub fn wasi_environ_get(
             return wasm32::__WASI_EOVERFLOW;
         }
     }
-
-    unsafe {
-        enc_slice_of(vmctx, environ.as_slice(), environ_ptr)
-            .map(|_| wasm32::__WASI_ESUCCESS)
-            .unwrap_or_else(|e| e)
-    }
+    enc_slice_of(vmctx, environ.as_slice(), environ_ptr)
+        .map(|_| wasm32::__WASI_ESUCCESS)
+        .unwrap_or_else(|e| e)
 }
 
 pub fn wasi_environ_sizes_get(
@@ -241,13 +230,11 @@ pub fn wasi_environ_sizes_get(
     if let Some(environ_size) = ctx.env.iter().try_fold(0, |acc: u32, pair| {
         acc.checked_add(pair.as_bytes_with_nul().len() as u32)
     }) {
-        unsafe {
-            if let Err(e) = enc_usize_byref(vmctx, environ_count_ptr, environ_count) {
-                return enc_errno(e);
-            }
-            if let Err(e) = enc_usize_byref(vmctx, environ_size_ptr, environ_size as usize) {
-                return enc_errno(e);
-            }
+        if let Err(e) = enc_usize_byref(vmctx, environ_count_ptr, environ_count) {
+            return enc_errno(e);
+        }
+        if let Err(e) = enc_usize_byref(vmctx, environ_size_ptr, environ_size as usize) {
+            return enc_errno(e);
         }
         wasm32::__WASI_ESUCCESS
     } else {


### PR DESCRIPTION
- Remove unneeded `unsafe` blocks; codecs don't need these any longer.
- Removing a directory without `REMOVEDIR` may return `EPERM` instead of  `EISDIR`. Adjust accordingly. (thanks, @kubkon)
- If a path cannot be opened, set the file descriptor to `wasi_fd_t::max_value()`

This is fixing tests from https://github.com/sunfishcode/misc-tests 