### PR TITLE
lucet-runtime: add missing lucet_error_no_linear_memory in C header

### DIFF
--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -22,6 +22,7 @@ enum lucet_error {
     lucet_error_region_full,
     lucet_error_module,
     lucet_error_limits_exceeded,
+    lucet_error_no_linear_memory,
     lucet_error_symbol_not_found,
     lucet_error_func_not_found,
     lucet_error_runtime_fault,


### PR DESCRIPTION
Error::NoLinearMemory was added in d03aaad7b198ab4e4eff442e213871801df5c36f, but it didn't update the C header, causing GDB to display lucet_error incorrectly.

This change makes the definition of `lucet_error` in `lucet_types.h` same with `Error` in [error.rs](https://github.com/fastly/lucet/blob/master/lucet-runtime/lucet-runtime-internals/src/error.rs)