### PR TITLE
Update AssemblyScript, WASA and the AssemblyScript example and instructions

### DIFF
--- a/assemblyscript/examples/signatures/README.md
+++ b/assemblyscript/examples/signatures/README.md
@@ -24,6 +24,7 @@ npm install
 npm run asbuild:optimized
 
 lucetc -o example \
+  --reserved-size=64MB \
   --bindings /opt/lucet/share/assemblyscript/modules/wasa/bindings.json \
   build/optimized.wasm
 ```
@@ -31,7 +32,7 @@ lucetc -o example \
 ## Running the example using lucet-wasi
 
 ```sh
-lucet-wasi --entrypoint main --dir /lucet:/lucet example help
+lucet-wasi --entrypoint main --dir .:. example help
 ```
 
 Unlike C and Rust applications, AssemblyScript requires an entry point to be explicitly defined.
@@ -43,7 +44,7 @@ Since files are going to be read and written to, a descriptor to a pre-opened di
 
 This is the purpose of the `--dir` command-line option. Without this, the webassembly module cannot access the filesystem at all.
 
-Here, the `/lucet` virtual directory, as seen by the application, maps to the `/lucet` directory in the container.
+Here, the current virtual directory (`.`), as seen by the application, maps to the current directory in the container.
 
 ## What the example does
 
@@ -54,7 +55,7 @@ The main code is in `assembly/index.ts`.
 Key pair creation:
 
 ```sh
-lucet-wasi --entrypoint main --dir /lucet:/lucet example keypair
+lucet-wasi --entrypoint main --dir .:. example keypair
 ```
 
 ```text
@@ -63,7 +64,7 @@ Key pair created and saved into [keypair.bin]
 Public key: [94b8eb14373eb245c1daaacb2c24e2cb554bdd723009423aae5a8ca5fa99fa16]
 ```
 
-A new file `keypair.bin` is created on the local filesystem, at the root of the first mount point (`/lucet`).
+A new file `keypair.bin` is created on the local filesystem, at the root of the first mount point (the current directory).
 
 An environment variable called `KEYPAIR_FILE`, can be used in order to change the file name and location.
 
@@ -72,19 +73,19 @@ The WASA wrapper automatically sets the minimum required WASI capabilities in or
 File signature:
 
 ```sh
-lucet-wasi --entrypoint main --dir /lucet:/lucet example sign LICENSE
+lucet-wasi --entrypoint main --dir .:. example sign README.md
 ```
 
 ```text
 Signature for that file: [deedf3910d5b166ca17e0e307312a422cb50efcbcc90754cf0e2d528a9159c4ad3ac973e3cd9b2c2986fb2e467a0506bc9a5ceb9c7d6d30e360fb4d1cef3c50d]
 ```
 
-This command reads the `/lucet/LICENSE` file, as well as the key pair, and computes a signature of the file's content that can be verified using the public key.
+This command reads the `README.md` file, as well as the key pair, and computes a signature of the file's content that can be verified using the public key.
 
 Signature verification:
 
 ```sh
-lucet-wasi --entrypoint main --dir /lucet:/lucet example verify LICENSE 94b8eb14373eb245c1daaacb2c24e2cb554bdd723009423aae5a8ca5fa99fa16 deedf3910d5b166ca17e0e307312a422cb50efcbcc90754cf0e2d528a9159c4ad3ac973e3cd9b2c2986fb2e467a0506bc9a5ceb9c7d6d30e360fb4d1cef3c50d
+lucet-wasi --entrypoint main --dir .:. example verify README.md 94b8eb14373eb245c1daaacb2c24e2cb554bdd723009423aae5a8ca5fa99fa16 deedf3910d5b166ca17e0e307312a422cb50efcbcc90754cf0e2d528a9159c4ad3ac973e3cd9b2c2986fb2e467a0506bc9a5ceb9c7d6d30e360fb4d1cef3c50d
 ```
 
 ```text

--- a/assemblyscript/examples/signatures/README.md
+++ b/assemblyscript/examples/signatures/README.md
@@ -85,8 +85,10 @@ This command reads the `README.md` file, as well as the key pair, and computes a
 Signature verification:
 
 ```sh
-lucet-wasi --entrypoint main --dir .:. example verify README.md 94b8eb14373eb245c1daaacb2c24e2cb554bdd723009423aae5a8ca5fa99fa16 deedf3910d5b166ca17e0e307312a422cb50efcbcc90754cf0e2d528a9159c4ad3ac973e3cd9b2c2986fb2e467a0506bc9a5ceb9c7d6d30e360fb4d1cef3c50d
+lucet-wasi --entrypoint main --dir .:. example verify README.md <public key> <signature>
 ```
+
+`<public key>` and `<signature>` must be replaced with output from the previous commands.
 
 ```text
 This is a valid signature for that file

--- a/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/faRistrettoPoint.spec.ts
+++ b/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/faRistrettoPoint.spec.ts
@@ -4,7 +4,7 @@ describe("Ristretto arithmetic", (): void => {
         for (let i = 0; i < 64; i++) {
             uniform[i] = i;
         }
-        let p = faPointFromUniform(uniform);
+        let p = faPointFromHash(uniform);
         expect<bool>(faPointValidate(p)).toBeTruthy();
         p[0]++;
         expect<bool>(faPointValidate(p)).toBeFalsy();
@@ -14,7 +14,7 @@ describe("Ristretto arithmetic", (): void => {
         for (let i = 0; i < 64; i++) {
             uniform2[i] = ~i;
         }
-        let p2 = faPointFromUniform(uniform2);
+        let p2 = faPointFromHash(uniform2);
         expect<bool>(faPointValidate(p2)).toBeTruthy();
         p2[0]++;
         expect<bool>(faPointValidate(p2)).toBeFalsy();

--- a/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/hash.spec.ts
+++ b/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/hash.spec.ts
@@ -1,0 +1,9 @@
+describe("hashing", (): void => {
+    it("should compute the hash of an empty string", (): void => {
+        let h = hashFinal(hashInit());
+        let hex = bin2hex(h);
+        expect<string>(hex).toBe(
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        );
+    });
+});

--- a/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/utils.spec.ts
+++ b/assemblyscript/examples/signatures/assembly/wasm-crypto/__tests__/utils.spec.ts
@@ -37,11 +37,11 @@ describe("bin2hex", (): void => {
 describe("hex2bin", (): void => {
   it("shoud decode from hex", (): void => {
     let hex = "00050a0f14191e23282d32373c41464b50555a5f64696e7378";
-    let bin = hex2bin(hex)!;
+    let bin = hex2bin(hex);
     let ref = new Uint8Array(25);
     for (let i = 0; i < 25; i++) {
       ref[i] = i * 5;
     }
-    expect<bool>(equals(ref, bin)).toBeTruthy();
+    expect<bool>(equals(ref, bin!)).toBeTruthy();
   })
 })

--- a/assemblyscript/examples/signatures/package-lock.json
+++ b/assemblyscript/examples/signatures/package-lock.json
@@ -1,0 +1,153 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
+    "assemblyscript": {
+      "version": "github:AssemblyScript/assemblyscript#678593d7bd8ee9573eadbd43e3635e0bc0b8e15e",
+      "from": "github:AssemblyScript/assemblyscript",
+      "dev": true,
+      "requires": {
+        "@protobufjs/utf8": "^1.1.0",
+        "binaryen": "84.0.0-nightly.20190522",
+        "glob": "^7.1.4",
+        "long": "^4.0.0",
+        "opencollective-postinstall": "^2.0.0",
+        "source-map-support": "^0.5.12"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binaryen": {
+      "version": "84.0.0-nightly.20190522",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-84.0.0-nightly.20190522.tgz",
+      "integrity": "sha512-bxSPi3MOkFmK5W6VIlqxnOc1nYzpUCzT/tHz3C7sgbz7jTR2lOBlZnKStTJlBt018xeZK9/JpK/jXdduH7eQFg==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/assemblyscript/examples/signatures/package.json
+++ b/assemblyscript/examples/signatures/package.json
@@ -1,13 +1,11 @@
 {
-  "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm",
-    "asbuild:small": "asc assembly/index.ts -b build/small.wasm -t build/small.wat -O3z --importMemory",
-    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -O3 --importMemory",
-    "asbuild": "npm run asbuild:optimized",
-    "test": "asp"
-  },
-  "devDependencies": {
-    "as-pect": "github:jtenner/as-pect",
-    "assemblyscript": "github:AssemblyScript/assemblyscript"
-  }
+    "scripts": {
+        "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm --runtime stub --use abort=wasi_abort",
+        "asbuild:small": "asc assembly/index.ts -b build/small.wasm -t build/small.wat -O3z --runtime stub --use abort=wasi_abort",
+        "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat -O3 --runtime stub --use abort=wasi_abort",
+        "asbuild": "npm run asbuild:optimized"
+    },
+    "devDependencies": {
+        "assemblyscript": "github:AssemblyScript/assemblyscript"
+    }
 }

--- a/assemblyscript/modules/wasa/README.md
+++ b/assemblyscript/modules/wasa/README.md
@@ -1,6 +1,6 @@
 # An AssemblyScript layer for the WebAssembly System Interface (WASI)
 
-[WASI](https://github.com/CraneStation/wasmtime-wasi/blob/wasi/docs/WASI-overview.md) is an API providing access to the external world to WebAssembly modules.
+[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules.
 
 WASA is an effort to expose the WASI standard set of system calls to AssemblyScript.
 
@@ -9,10 +9,9 @@ WASA is an effort to expose the WASI standard set of system calls to AssemblyScr
 Example usage of the `Console` and `Environ` classes:
 
 ```typescript
-import "allocator/arena";
 import { Console, Environ } from "../node_modules/wasa/assembly";
 
 let env = new Environ();
-let home = env.get("HOME") as String;
+let home = env.get("HOME")!;
 Console.log(home);
 ```

--- a/assemblyscript/modules/wasa/assembly/index.ts
+++ b/assemblyscript/modules/wasa/assembly/index.ts
@@ -1,5 +1,9 @@
-import { IO, Console, Random, Date, Process, EnvironEntry, Environ, CommandLine, Filesystem } from "./wasa";
+import {
+  WASAError, Descriptor,
+  Console, Random, Date, Process, EnvironEntry, Environ, CommandLine, FileSystem, FileStat
+} from "./wasa";
 
 export {
-  IO, Console, Random, Date, Process, EnvironEntry, Environ, CommandLine, Filesystem
-}
+  WASAError, Descriptor,
+  Console, Random, Date, Process, EnvironEntry, Environ, CommandLine, FileSystem, FileStat
+};

--- a/assemblyscript/modules/wasa/assembly/wasa.ts
+++ b/assemblyscript/modules/wasa/assembly/wasa.ts
@@ -1,178 +1,348 @@
-// The entry file of your WebAssembly module.
-
 import {
-  errno,
-  clockid,
-  fd_write,
-  fd_read,
-  random_get,
-  clock_time_get,
-  clock_res_get,
-  proc_exit,
-  environ_sizes_get,
-  environ_get,
-  args_sizes_get,
+  advice,
   args_get,
-  path_open,
-  oflags,
-  rights,
-  lookupflags,
+  args_sizes_get,
+  clock_res_get,
+  clock_time_get,
+  clockid,
+  dircookie,
+  environ_get,
+  environ_sizes_get,
+  errno,
+  fd_advise,
+  fd_allocate,
+  fd_close,
+  fd_datasync,
+  fd_fdstat_get,
+  fd_fdstat_set_flags,
+  fd_filestat_get,
+  fd_filestat_set_size,
+  fd_filestat_set_times,
+  fd_prestat_dir_name,
+  fd_read,
+  fd_readdir,
+  fd_seek,
+  fd_sync,
+  fd_tell,
+  fd_write,
   fd,
   fdflags,
-  fd_close,
-} from 'bindings/wasi';
+  fdstat,
+  whence,
+  filesize,
+  filestat,
+  filetype,
+  fstflags,
+  lookupflags,
+  oflags,
+  path_create_directory,
+  path_filestat_get,
+  path_link,
+  path_open,
+  path_rename,
+  path_remove_directory,
+  path_symlink,
+  path_unlink_file,
+  proc_exit,
+  random_get,
+  rights,
+} from "bindings/wasi";
 
-export type Descriptor = fd;
-
-export class Filesystem {
-  /**
-   * A simplified interface to open a file for read operations
-   * @param path Path
-   * @param dirfd Base directory descriptor (will be automatically set soon)
-   */
-  static openForRead(path: string, dirfd: Descriptor = 3): Descriptor | null {
-    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
-    let fd_oflags: oflags = 0;
-    let fd_rights = rights.FD_READ | rights.FD_SEEK |
-      rights.FD_TELL | rights.FD_FILESTAT_GET;
-    let fd_rights_inherited = fd_rights;
-    let fd_flags: fdflags = 0;
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
-    let fd_buf = memory.allocate(sizeof<u32>());
-    let res = path_open(dirfd as fd, fd_lookup_flags, path_utf8, path_utf8_len,
-      fd_oflags, fd_rights, fd_rights_inherited, fd_flags, fd_buf);
-    if (res != errno.SUCCESS) {
-      return null;
-    }
-    let fd = load<u32>(fd_buf);
-    memory.free(fd_buf);
-
-    return fd as Descriptor;
-  }
-
-  /**
-  * A simplified interface to open a file for write operations
-  * @param path Path
-  * @param dirfd Base directory descriptor (will be automatically set soon)
-  */
-  static openForWrite(path: string, dirfd: Descriptor = 3): Descriptor | null {
-    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
-    let fd_oflags: oflags = oflags.CREAT;
-    let fd_rights = rights.FD_WRITE | rights.FD_SEEK |
-      rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
-    let fd_rights_inherited = fd_rights;
-    let fd_flags: fdflags = 0;
-    let path_utf8_len: usize = path.lengthUTF8 - 1;
-    let path_utf8 = path.toUTF8();
-    let fd_buf = memory.allocate(sizeof<u32>());
-    let res = path_open(dirfd as fd, fd_lookup_flags, path_utf8, path_utf8_len,
-      fd_oflags, fd_rights, fd_rights_inherited, fd_flags, fd_buf);
-    if (res != errno.SUCCESS) {
-      return null;
-    }
-    let fd = load<u32>(fd_buf);
-    memory.free(fd_buf);
-
-    return fd as Descriptor;
+/**
+ * A WASA error
+ */
+export class WASAError extends Error {
+  constructor(message: string = "") {
+    super(message);
+    this.name = "WASAError";
   }
 }
 
-export class IO {
+/**
+ * Portable information about a file
+ */
+export class FileStat {
+  file_type: filetype;
+  file_size: filesize;
+  access_time: f64;
+  modification_time: f64;
+  creation_time: f64;
+
+  constructor(st_buf: usize) {
+    this.file_type = load<u8>(st_buf + 16);
+    this.file_size = load<u64>(st_buf + 24);
+    this.access_time = (load<u64>(st_buf + 32) as f64) / 1e9;
+    this.modification_time = (load<u64>(st_buf + 40) as f64) / 1e9;
+    this.creation_time = (load<u64>(st_buf + 48) as f64) / 1e9;
+  }
+}
+
+/**
+ * A descriptor, that doesn't necessarily have to represent a file
+ */
+export class Descriptor {
+  /**
+   * An invalid file descriptor, that can represent an error
+   */
+  static Invalid(): Descriptor { return new Descriptor(-1); };
+
+  /**
+   * The standard input
+   */
+  static Stdin(): Descriptor { return new Descriptor(0); };
+
+  /**
+   * The standard output
+   */
+  static Stdout(): Descriptor { return new Descriptor(1); };
+
+  /**
+   * The standard error
+   */
+  static Stderr(): Descriptor { return new Descriptor(2); };
+
+  /**
+   * Build a new descriptor from a raw WASI file descriptor
+   * @param rawfd a raw file descriptor
+   */
+  constructor(readonly rawfd: fd) { }
+
+  /**
+   * Hint at how the data accessible via the descriptor will be used
+   * @offset offset
+   * @len length
+   * @advice `advice.{NORMAL, SEQUENTIAL, RANDOM, WILLNEED, DONTNEED, NOREUSE}`
+   * @returns `true` on success, `false` on error
+   */
+  advise(offset: u64, len: u64, advice: advice): bool {
+    return fd_advise(this.rawfd, offset, len, advice) === errno.SUCCESS;
+  }
+
+  /**
+   * Preallocate data
+   * @param offset where to start preallocating data in the file
+   * @param len bytes to preallocate
+   * @returns `true` on success, `false` on error
+   */
+  allocate(offset: u64, len: u64): bool {
+    return fd_allocate(this.rawfd, offset, len) === errno.SUCCESS;
+  }
+
+  /**
+   * Wait for the data to be written
+   * @returns `true` on success, `false` on error
+   */
+  fdatasync(): bool {
+    return fd_datasync(this.rawfd) === errno.SUCCESS;
+  }
+
+  /**
+   * Wait for the data and metadata to be written
+   * @returns `true` on success, `false` on error
+   */
+  fsync(): bool {
+    return fd_sync(this.rawfd) === errno.SUCCESS;
+  }
+
+  /**
+   * Return the file type
+   */
+  fileType(): filetype {
+    let st_buf = changetype<usize>(new ArrayBuffer(24));
+    if (fd_fdstat_get(this.rawfd, changetype<fdstat>(st_buf)) !== errno.SUCCESS) {
+      throw new WASAError("Unable to get the file type");
+    }
+    let file_type: u8 = load<u8>(st_buf);
+
+    return file_type;
+  }
+
+  /**
+   * Set WASI flags for that descriptor
+   * @params flags: one or more of `fdflags.{APPEND, DSYNC, NONBLOCK, RSYNC, SYNC}`
+   * @returns `true` on success, `false` on error
+   */
+  setFlags(flags: fdflags): bool {
+    return fd_fdstat_set_flags(this.rawfd, flags) === errno.SUCCESS;
+  }
+
+  /**
+   * Retrieve information about a descriptor
+   * @returns a `FileStat` object`
+   */
+  stat(): FileStat {
+    let st_buf = changetype<usize>(new ArrayBuffer(56));
+    if (fd_filestat_get(this.rawfd, changetype<filestat>(st_buf)) !== errno.SUCCESS) {
+      throw new WASAError("Unable to get the file information");
+    }
+    return new FileStat(st_buf);
+  }
+
+  /**
+   * Change the size of a file
+   * @param size new size
+   * @returns `true` on success, `false` on error
+   */
+  ftruncate(size: u64 = 0): bool {
+    return fd_filestat_set_size(this.rawfd, size) === errno.SUCCESS;
+  }
+
+  /**
+   * Update the access time
+   * @ts timestamp in seconds
+   * @returns `true` on success, `false` on error
+   */
+  fatime(ts: f64): bool {
+    return (
+      fd_filestat_set_times(this.rawfd, (ts * 1e9) as u64, 0, fstflags.SET_ATIM) ===
+      errno.SUCCESS
+    );
+  }
+
+  /**
+   * Update the modification time
+   * @ts timestamp in seconds
+   * @returns `true` on success, `false` on error
+   */
+  fmtime(ts: f64): bool {
+    return (
+      fd_filestat_set_times(this.rawfd, 0, (ts * 1e9) as u64, fstflags.SET_MTIM) ===
+      errno.SUCCESS
+    );
+  }
+
+  /**
+   * Update both the access and the modification times
+   * @atime timestamp in seconds
+   * @mtime timestamp in seconds
+   * @returns `true` on success, `false` on error
+   */
+  futimes(atime: f64, mtime: f64): bool {
+    return (
+      fd_filestat_set_times(this.rawfd, (atime * 1e9) as u64, (mtime * 1e9) as u64,
+        fstflags.SET_ATIM | fstflags.SET_ATIM) === errno.SUCCESS
+    );
+  }
+
+  /**
+   * Update the timestamp of the object represented by the descriptor
+   * @returns `true` on success, `false` on error
+   */
+  touch(): bool {
+    return (
+      fd_filestat_set_times(
+        this.rawfd,
+        0,
+        0,
+        fstflags.SET_ATIM_NOW | fstflags.SET_MTIM_NOW
+      ) === errno.SUCCESS
+    );
+  }
+
+  /**
+   * Return the directory associated to that descriptor
+   */
+  dirName(): String {
+    let path_max: usize = 4096;
+    for (; ;) {
+      let path_buf = changetype<usize>(new ArrayBuffer(path_max));
+      let ret = fd_prestat_dir_name(this.rawfd, path_buf, path_max);
+      if (ret === errno.NAMETOOLONG) {
+        path_max = path_max * 2;
+        continue;
+      }
+      let path_len = 0;
+      while (load<u8>(path_buf + path_len) !== 0) {
+        path_len++;
+      }
+      return String.UTF8.decodeUnsafe(path_buf, path_len);
+    }
+  }
+
   /**
    * Close a file descriptor
-   * @param fd file descriptor
    */
-  static close(fd: Descriptor): void {
-    fd_close(fd);
+  close(): void {
+    fd_close(this.rawfd);
   }
 
   /**
    * Write data to a file descriptor
-   * @param fd file descriptor
    * @param data data
    */
-  static write(fd: Descriptor, data: Array<u8>): void {
+  write(data: Array<u8>): void {
     let data_buf_len = data.length;
-    let data_buf = memory.allocate(data_buf_len);
+    let data_buf = changetype<usize>(new ArrayBuffer(data_buf_len));
     for (let i = 0; i < data_buf_len; i++) {
       store<u8>(data_buf + i, unchecked(data[i]));
     }
-    let iov = memory.allocate(2 * sizeof<usize>());
+    let iov = changetype<usize>(new ArrayBuffer(2 * sizeof<usize>()));
     store<u32>(iov, data_buf);
     store<u32>(iov + sizeof<usize>(), data_buf_len);
-    let written_ptr = memory.allocate(sizeof<usize>());
-    fd_write(fd, iov, 1, written_ptr);
-    memory.free(written_ptr);
-    memory.free(data_buf);
+
+    let written_ptr = changetype<usize>(new ArrayBuffer(sizeof<usize>()));
+    fd_write(this.rawfd, iov, 1, written_ptr);
   }
 
   /**
-   * Write a string to a file descriptor, after encoding it to UTF8
-   * @param fd file descriptor
-   * @param s string
-   * @param newline `true` to add a newline after the string
-   */
-  static writeString(fd: Descriptor, s: string, newline: bool = false): void {
+     * Write a string to a file descriptor, after encoding it to UTF8
+     * @param s string
+     * @param newline `true` to add a newline after the string
+     */
+  writeString(s: string, newline: bool = false): void {
     if (newline) {
-      this.writeStringLn(fd, s);
+      this.writeStringLn(s);
       return;
     }
-    let s_utf8_len: usize = s.lengthUTF8 - 1;
-    let s_utf8 = s.toUTF8();
-    let iov = memory.allocate(2 * sizeof<usize>());
+    let s_utf8_len: usize = String.UTF8.byteLength(s);
+    let s_utf8 = changetype<usize>(String.UTF8.encode(s));
+    let iov = changetype<usize>(new ArrayBuffer(2 * sizeof<usize>()));
     store<u32>(iov, s_utf8);
     store<u32>(iov + sizeof<usize>(), s_utf8_len);
-    let written_ptr = memory.allocate(sizeof<usize>());
-    fd_write(fd, iov, 1, written_ptr);
-    memory.free(written_ptr);
-    memory.free(s_utf8);
+    let written_ptr = changetype<usize>(new ArrayBuffer(sizeof<usize>()));
+    fd_write(this.rawfd, iov, 1, written_ptr);
   }
 
   /**
    * Write a string to a file descriptor, after encoding it to UTF8, with a newline
-   * @param fd file descriptor
    * @param s string
    */
-  static writeStringLn(fd: Descriptor, s: string): void {
-    let s_utf8_len: usize = s.lengthUTF8 - 1;
-    let s_utf8 = s.toUTF8();
-    let iov = memory.allocate(4 * sizeof<usize>());
+  writeStringLn(s: string): void {
+    let s_utf8_len: usize = String.UTF8.byteLength(s);
+    let s_utf8 = changetype<usize>(String.UTF8.encode(s));
+    let iov = changetype<usize>(new ArrayBuffer(4 * sizeof<usize>()));
     store<u32>(iov, s_utf8);
     store<u32>(iov + sizeof<usize>(), s_utf8_len);
-    let lf = memory.allocate(1);
+    let lf = changetype<usize>(new ArrayBuffer(1));
     store<u8>(lf, 10);
     store<u32>(iov + sizeof<usize>() * 2, lf);
     store<u32>(iov + sizeof<usize>() * 3, 1);
-    let written_ptr = memory.allocate(sizeof<usize>());
-    fd_write(fd, iov, 2, written_ptr);
-    memory.free(written_ptr);
-    memory.free(s_utf8);
+    let written_ptr = changetype<usize>(new ArrayBuffer(sizeof<usize>()));
+    fd_write(this.rawfd, iov, 2, written_ptr);
   }
 
   /**
    * Read data from a file descriptor
-   * @param fd file descriptor
    * @param data existing array to push data to
    * @param chunk_size chunk size (default: 4096)
    */
-  static read(fd: Descriptor, data: Array<u8> = [], chunk_size: usize = 4096): Array<u8> | null {
+  read(
+    data: Array<u8> = [],
+    chunk_size: usize = 4096
+  ): Array<u8> | null {
     let data_partial_len = chunk_size;
-    let data_partial = memory.allocate(data_partial_len);
-    let iov = memory.allocate(2 * sizeof<usize>());
+    let data_partial = changetype<usize>(new ArrayBuffer(data_partial_len));
+    let iov = changetype<usize>(new ArrayBuffer(2 * sizeof<usize>()));
     store<u32>(iov, data_partial);
     store<u32>(iov + sizeof<usize>(), data_partial_len);
-    let read_ptr = memory.allocate(sizeof<usize>());
-    fd_read(fd, iov, 1, read_ptr);
+    let read_ptr = changetype<usize>(new ArrayBuffer(sizeof<usize>()));
+    fd_read(this.rawfd, iov, 1, read_ptr);
     let read = load<usize>(read_ptr);
     if (read > 0) {
       for (let i: usize = 0; i < read; i++) {
         data.push(load<u8>(data_partial + i));
       }
     }
-    memory.free(read_ptr);
-    memory.free(data_partial);
-
     if (read <= 0) {
       return null;
     }
@@ -181,20 +351,22 @@ export class IO {
 
   /**
    * Read from a file descriptor until the end of the stream
-   * @param fd file descriptor
    * @param data existing array to push data to
    * @param chunk_size chunk size (default: 4096)
    */
-  static readAll(fd: Descriptor, data: Array<u8> = [], chunk_size: usize = 4096): Array<u8> | null {
+  readAll(
+    data: Array<u8> = [],
+    chunk_size: usize = 4096
+  ): Array<u8> | null {
     let data_partial_len = chunk_size;
-    let data_partial = memory.allocate(data_partial_len);
-    let iov = memory.allocate(2 * sizeof<usize>());
+    let data_partial = changetype<usize>(new ArrayBuffer(data_partial_len));
+    let iov = changetype<usize>(new ArrayBuffer(2 * sizeof<usize>()));
     store<u32>(iov, data_partial);
     store<u32>(iov + sizeof<usize>(), data_partial_len);
-    let read_ptr = memory.allocate(sizeof<usize>());
+    let read_ptr = changetype<usize>(new ArrayBuffer(sizeof<usize>()));
     let read: usize = 0;
     for (; ;) {
-      if (fd_read(fd, iov, 1, read_ptr) != errno.SUCCESS) {
+      if (fd_read(this.rawfd, iov, 1, read_ptr) !== errno.SUCCESS) {
         break;
       }
       read = load<usize>(read_ptr);
@@ -205,9 +377,6 @@ export class IO {
         data.push(load<u8>(data_partial + i));
       }
     }
-    memory.free(read_ptr);
-    memory.free(data_partial);
-
     if (read < 0) {
       return null;
     }
@@ -216,24 +385,310 @@ export class IO {
 
   /**
    * Read an UTF8 string from a file descriptor, convert it to a native string
-   * @param fd file descriptor
    * @param chunk_size chunk size (default: 4096)
    */
-  static readString(fd: Descriptor, chunk_size: usize = 4096): string | null {
-    let s_utf8_ = IO.readAll(fd);
-    if (s_utf8_ === null) {
+  readString(chunk_size: usize = 4096): string | null {
+    let s_utf8 = this.readAll();
+    if (s_utf8 === null) {
       return null;
     }
-    let s_utf8 = s_utf8_!;
     let s_utf8_len = s_utf8.length;
-    let s_utf8_buf = memory.allocate(s_utf8_len);
+    let s_utf8_buf = changetype<usize>(new ArrayBuffer(s_utf8_len));
     for (let i = 0; i < s_utf8_len; i++) {
       store<u8>(s_utf8_buf + i, s_utf8[i]);
     }
-    let s = String.fromUTF8(s_utf8_buf, s_utf8.length);
-    memory.free(s_utf8_buf);
+    let s = String.UTF8.decodeUnsafe(s_utf8_buf, s_utf8.length);
 
     return s;
+  }
+
+  /**
+   * Seek into a stream
+   * @off offset
+   * @w the position relative to which to set the offset of the file descriptor.
+   */
+  seek(off: u64, w: whence): bool {
+    let fodder = changetype<usize>(new ArrayBuffer(8));
+    let res = fd_seek(this.rawfd, off, w, fodder);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Return the current offset in the stream
+   * @returns offset
+   */
+  tell(): u64 {
+    let buf_off = changetype<usize>(new ArrayBuffer(8));
+    let res = fd_tell(this.rawfd, buf_off);
+    if (res !== errno.SUCCESS) {
+      abort();
+    }
+    return load<u64>(buf_off);
+  }
+}
+
+/**
+ * A class to access a filesystem
+ */
+export class FileSystem {
+  /**
+   * Open a path
+   * @path path
+   * @flags r, r+, w, wx, w+ or xw+
+   * @returns a descriptor
+   */
+  static open(path: string, flags: string = "r"): Descriptor | null {
+    let dirfd = this.dirfdForPath(path);
+    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
+    let fd_oflags: u16 = 0;
+    let fd_rights: u64 = 0;
+    if (flags === "r") {
+      fd_rights = rights.FD_READ | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.FD_READDIR;
+    } else if (flags === "r+") {
+      fd_rights =
+        rights.FD_READ | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.FD_WRITE |
+        rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
+    } else if (flags === "w") {
+      fd_oflags = oflags.CREAT | oflags.TRUNC;
+      fd_rights = rights.FD_WRITE | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
+    } else if (flags === "wx") {
+      fd_oflags = oflags.CREAT | oflags.TRUNC | oflags.EXCL;
+      fd_rights = rights.FD_WRITE | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
+    } else if (flags === "w+") {
+      fd_oflags = oflags.CREAT | oflags.TRUNC;
+      fd_rights =
+        rights.FD_READ | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.FD_WRITE |
+        rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
+    } else if (flags === "xw+") {
+      fd_oflags = oflags.CREAT | oflags.TRUNC | oflags.EXCL;
+      fd_rights =
+        rights.FD_READ | rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.FD_WRITE |
+        rights.FD_SEEK | rights.FD_TELL | rights.FD_FILESTAT_GET | rights.PATH_CREATE_FILE;
+    } else {
+      return null;
+    }
+    let fd_rights_inherited = fd_rights;
+    let fd_flags: fdflags = 0;
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let fd_buf = changetype<usize>(new ArrayBuffer(sizeof<u32>()));
+    let res = path_open(
+      dirfd as fd,
+      fd_lookup_flags,
+      path_utf8,
+      path_utf8_len,
+      fd_oflags,
+      fd_rights,
+      fd_rights_inherited,
+      fd_flags,
+      fd_buf
+    );
+    if (res !== errno.SUCCESS) {
+      return null;
+    }
+    let fd = load<u32>(fd_buf);
+
+    return new Descriptor(fd);
+  }
+
+  /**
+   * Create a new directory
+   * @path path
+   * @returns `true` on success, `false` on failure
+   */
+  static mkdir(path: string): bool {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let res = path_create_directory(dirfd, path_utf8, path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Check if a file exists at a given path
+   * @path path
+   * @returns `true` on success, `false` on failure
+   */
+  static exists(path: string): bool {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
+    let st_buf = changetype<usize>(new ArrayBuffer(56));
+    let res = path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len,
+      changetype<filestat>(st_buf));
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Create a hard link
+   * @old_path old path
+   * @new_path new path
+   * @returns `true` on success, `false` on failure
+   */
+  static link(old_path: string, new_path: string): bool {
+    let old_dirfd = this.dirfdForPath(old_path);
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = changetype<usize>(String.UTF8.encode(old_path));
+    let new_dirfd = this.dirfdForPath(new_path);
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = changetype<usize>(String.UTF8.encode(new_path));
+    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
+    let res = path_link(old_dirfd, fd_lookup_flags, old_path_utf8, old_path_utf8_len,
+      new_dirfd, new_path_utf8, new_path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Create a symbolic link
+   * @old_path old path
+   * @new_path new path
+   * @returns `true` on success, `false` on failure
+   */
+  static symlink(old_path: string, new_path: string): bool {
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = changetype<usize>(String.UTF8.encode(old_path));
+    let new_dirfd = this.dirfdForPath(new_path);
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = changetype<usize>(String.UTF8.encode(new_path));
+    let res = path_symlink(old_path_utf8, old_path_utf8_len,
+      new_dirfd, new_path_utf8, new_path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Unlink a file
+   * @path path
+   * @returns `true` on success, `false` on failure
+   */
+  static unlink(path: string): bool {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let res = path_unlink_file(dirfd, path_utf8, path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Remove a directory
+   * @path path
+   * @returns `true` on success, `false` on failure
+   */
+  static rmdir(path: string): bool {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let res = path_remove_directory(dirfd, path_utf8, path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Retrieve information about a file
+   * @path path
+   * @returns a `FileStat` object
+   */
+  static stat(path: string): FileStat {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let fd_lookup_flags = lookupflags.SYMLINK_FOLLOW;
+    let st_buf = changetype<usize>(new ArrayBuffer(56));
+    if (path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len, changetype<filestat>(st_buf)) !== errno.SUCCESS) {
+      throw new WASAError("Unable to get the file information");
+    }
+    return new FileStat(st_buf);
+  }
+
+  /**
+   * Retrieve information about a file or a symbolic link
+   * @path path
+   * @returns a `FileStat` object
+   */
+  static lstat(path: string): FileStat {
+    let dirfd = this.dirfdForPath(path);
+    let path_utf8_len: usize = String.UTF8.byteLength(path);
+    let path_utf8 = changetype<usize>(String.UTF8.encode(path));
+    let fd_lookup_flags = 0;
+    let st_buf = changetype<usize>(new ArrayBuffer(56));
+    if (path_filestat_get(dirfd, fd_lookup_flags, path_utf8, path_utf8_len, changetype<filestat>(st_buf)) !== errno.SUCCESS) {
+      throw new WASAError("Unable to get the file information");
+    }
+    return new FileStat(st_buf);
+  }
+
+  /**
+   * Rename a file
+   * @old_path old path
+   * @new_path new path
+   * @returns `true` on success, `false` on failure
+   */
+  static rename(old_path: string, new_path: string): bool {
+    let old_dirfd = this.dirfdForPath(old_path);
+    let old_path_utf8_len: usize = String.UTF8.byteLength(old_path);
+    let old_path_utf8 = changetype<usize>(String.UTF8.encode(old_path));
+    let new_dirfd = this.dirfdForPath(new_path);
+    let new_path_utf8_len: usize = String.UTF8.byteLength(new_path);
+    let new_path_utf8 = changetype<usize>(String.UTF8.encode(new_path));
+    let res = path_rename(old_dirfd, old_path_utf8, old_path_utf8_len,
+      new_dirfd, new_path_utf8, new_path_utf8_len);
+
+    return res === errno.SUCCESS;
+  }
+
+  /**
+   * Get the content of a directory
+   * @param path the directory path
+   * @returns An array of file names
+   */
+  static readdir(path: string): Array<string> | null {
+    let fd = this.open(path, "r");
+    if (fd === null) {
+      return null;
+    }
+    let out = new Array<string>();
+    let buf = null;
+    let buf_size = 4096;
+    let buf_used_p = changetype<usize>(new ArrayBuffer(4));
+    let buf_used = 0;
+    for (; ;) {
+      buf = __alloc(buf_size, 0);
+      if (fd_readdir(fd.rawfd, buf, buf_size, 0 as dircookie, buf_used_p) !== errno.SUCCESS) {
+        fd.close();
+      }
+      buf_used = load<u32>(buf_used_p);
+      if (buf_used < buf_size) {
+        break;
+      }
+      buf_size <<= 1;
+      __free(buf);
+    }
+    let offset = 0;
+    while (offset < buf_used) {
+      offset += 16;
+      let name_len = load<u32>(buf + offset);
+      offset += 8;
+      if (offset + name_len > buf_used) {
+        return null;
+      }
+      let name = String.UTF8.decodeUnsafe(buf + offset, name_len);
+      out.push(name);
+      offset += name_len;
+    }
+    __free(buf);
+    fd.close();
+
+    return out;
+  }
+
+  protected static dirfdForPath(path: string): fd {
+    return 3;
   }
 }
 
@@ -245,14 +700,14 @@ export class Console {
    * @param newline `false` to avoid inserting a newline after the string
    */
   static write(s: string, newline: bool = true): void {
-    IO.writeString(1, s, newline);
+    Descriptor.Stdout().writeString(s, newline);
   }
 
   /**
    * Read an UTF8 string from the console, convert it to a native string
    */
   static readAll(): string | null {
-    return IO.readString(0);
+    return Descriptor.Stdin().readString();
   }
 
   /**
@@ -268,7 +723,7 @@ export class Console {
    * @param newline `false` to avoid inserting a newline after the string
    */
   static error(s: string, newline: bool = true): void {
-    IO.writeString(2, s, newline);
+    Descriptor.Stderr().writeString(s, newline);
   }
 }
 
@@ -279,10 +734,10 @@ export class Random {
    */
   static randomFill(buffer: ArrayBuffer): void {
     let len = buffer.byteLength;
-    let ptr = buffer.data;
+    let ptr = changetype<usize>(buffer);
     while (len > 0) {
       let chunk = min(len, 256);
-      if (random_get(ptr, chunk) != errno.SUCCESS) {
+      if (random_get(ptr, chunk) !== errno.SUCCESS) {
         abort();
       }
       len -= chunk;
@@ -306,20 +761,20 @@ export class Date {
    * Return the current timestamp, as a number of milliseconds since the epoch
    */
   static now(): f64 {
-    let time_ptr = memory.allocate(8);
+    let time_ptr = changetype<usize>(new ArrayBuffer(8));
     clock_time_get(clockid.REALTIME, 1000, time_ptr);
     let unix_ts = load<u64>(time_ptr);
-    memory.free(time_ptr);
-    return unix_ts as f64 / 1000.0;
+
+    return (unix_ts as f64) / 1000.0;
   }
 }
 
 export class Performance {
   static now(): f64 {
-    let time_ptr = memory.allocate(8);
+    let time_ptr = changetype<usize>(new ArrayBuffer(8));
     clock_res_get(clockid.MONOTONIC, time_ptr);
     let res_ts = load<u64>(time_ptr);
-    memory.free(time_ptr);
+
     return res_ts as f64;
   }
 }
@@ -330,12 +785,12 @@ export class Process {
    * @param status exit code
    */
   static exit(status: u32): void {
-    proc_exit(status)
+    proc_exit(status);
   }
 }
 
 export class EnvironEntry {
-  constructor(readonly key: string, readonly value: string) { };
+  constructor(readonly key: string, readonly value: string) { }
 }
 
 export class Environ {
@@ -343,16 +798,20 @@ export class Environ {
 
   constructor() {
     this.env = [];
-    let count_and_size = memory.allocate(2 * sizeof<usize>());
+    let count_and_size = changetype<usize>(
+      new ArrayBuffer(2 * sizeof<usize>())
+    );
     let ret = environ_sizes_get(count_and_size, count_and_size + 4);
-    if (ret != errno.SUCCESS) {
+    if (ret !== errno.SUCCESS) {
       abort();
     }
     let count = load<usize>(count_and_size);
     let size = load<usize>(count_and_size + sizeof<usize>());
-    let env_ptrs = memory.allocate((count + 1) * sizeof<usize>());
-    let buf = memory.allocate(size);
-    if (environ_get(env_ptrs, buf) != errno.SUCCESS) {
+    let env_ptrs = changetype<usize>(
+      new ArrayBuffer((count + 1) * sizeof<usize>())
+    );
+    let buf = changetype<usize>(new ArrayBuffer(size));
+    if (environ_get(env_ptrs, buf) !== errno.SUCCESS) {
       abort();
     }
     for (let i: usize = 0; i < count; i++) {
@@ -362,8 +821,6 @@ export class Environ {
       let value = env_ptr_split[1];
       this.env.push(new EnvironEntry(key, value));
     }
-    memory.free(buf);
-    memory.free(env_ptrs);
   }
 
   /**
@@ -379,7 +836,7 @@ export class Environ {
    */
   get(key: string): string | null {
     for (let i = 0, j = this.env.length; i < j; i++) {
-      if (this.env[i].key == key) {
+      if (this.env[i].key === key) {
         return this.env[i].value;
       }
     }
@@ -388,20 +845,24 @@ export class Environ {
 }
 
 export class CommandLine {
-  args: Array<String>;
+  args: Array<string>;
 
   constructor() {
     this.args = [];
-    let count_and_size = memory.allocate(2 * sizeof<usize>());
+    let count_and_size = changetype<usize>(
+      new ArrayBuffer(2 * sizeof<usize>())
+    );
     let ret = args_sizes_get(count_and_size, count_and_size + 4);
-    if (ret != errno.SUCCESS) {
+    if (ret !== errno.SUCCESS) {
       abort();
     }
     let count = load<usize>(count_and_size);
     let size = load<usize>(count_and_size + sizeof<usize>());
-    let env_ptrs = memory.allocate((count + 1) * sizeof<usize>());
-    let buf = memory.allocate(size);
-    if (args_get(env_ptrs, buf) != errno.SUCCESS) {
+    let env_ptrs = changetype<usize>(
+      new ArrayBuffer((count + 1) * sizeof<usize>())
+    );
+    let buf = changetype<usize>(new ArrayBuffer(size));
+    if (args_get(env_ptrs, buf) !== errno.SUCCESS) {
       abort();
     }
     for (let i: usize = 0; i < count; i++) {
@@ -409,14 +870,12 @@ export class CommandLine {
       let arg = StringUtils.fromCString(env_ptr);
       this.args.push(arg);
     }
-    memory.free(buf);
-    memory.free(env_ptrs);
   }
 
   /**
    * Return all the command-line arguments
    */
-  all(): Array<String> {
+  all(): Array<string> {
     return this.args;
   }
 
@@ -434,11 +893,28 @@ export class CommandLine {
 }
 
 class StringUtils {
+  /**
+   * Returns a native string from a zero-terminated C string
+   * @param cstring
+   * @returns native string
+   */
   static fromCString(cstring: usize): string {
     let size = 0;
-    while (load<u8>(cstring + size) != 0) {
+    while (load<u8>(cstring + size) !== 0) {
       size++;
     }
-    return String.fromUTF8(cstring, size);
+    return String.UTF8.decodeUnsafe(cstring, size);
   }
+}
+
+@global
+export function wasi_abort(
+  message: string | null = "",
+  fileName: string | null = "",
+  lineNumber: u32 = 0,
+  columnNumber: u32 = 0
+): void {
+  Console.error(fileName! + ":" + lineNumber.toString() + ":" + columnNumber.toString() +
+    ": error: " + message!);
+  proc_exit(255);
 }

--- a/assemblyscript/modules/wasa/bindings.json
+++ b/assemblyscript/modules/wasa/bindings.json
@@ -1,19 +1,48 @@
 {
-  "env": {
-    "abort": "abort"
-  },
-  "wasi_unstable": {
-    "fd_write": "__wasi_fd_write",
-    "fd_read": "__wasi_fd_read",
-    "fd_close": "__wasi_fd_close",
-    "random_get": "__wasi_random_get",
-    "clock_time_get": "__wasi_clock_time_get",
-    "clock_res_get": "__wasi_clock_res_get",
-    "proc_exit": "__wasi_proc_exit",
-    "environ_sizes_get": "__wasi_environ_sizes_get",
-    "environ_get": "__wasi_environ_get",
-    "args_sizes_get": "__wasi_args_sizes_get",
-    "args_get": "__wasi_args_get",
-    "path_open": "__wasi_path_open"
-  }
+    "env": {
+        "abort": "abort"
+    },
+    "wasi_unstable": {
+        "args_get": "__wasi_args_get",
+        "args_sizes_get": "__wasi_args_sizes_get",
+        "clock_res_get": "__wasi_clock_res_get",
+        "clock_time_get": "__wasi_clock_time_get",
+        "environ_get": "__wasi_environ_get",
+        "environ_sizes_get": "__wasi_environ_sizes_get",
+        "fd_advise": "__wasi_fd_advise",
+        "fd_allocate": "__wasi_fd_allocate",
+        "fd_close": "__wasi_fd_close",
+        "fd_datasync": "__wasi_fd_datasync",
+        "fd_fdstat_get": "__wasi_fd_fdstat_get",
+        "fd_fdstat_set_flags": "__wasi_fd_fdstat_set_flags",
+        "fd_fdstat_set_rights": "__wasi_fd_fdstat_set_rights",
+        "fd_filestat_get": "__wasi_fd_filestat_get",
+        "fd_filestat_set_size": "__wasi_fd_filestat_set_size",
+        "fd_filestat_set_times": "__wasi_fd_filestat_set_times",
+        "fd_pread": "__wasi_fd_pread",
+        "fd_prestat_dir_name": "__wasi_fd_prestat_dir_name",
+        "fd_prestat_get": "__wasi_fd_prestat_get",
+        "fd_pwrite": "__wasi_fd_pwrite",
+        "fd_read": "__wasi_fd_read",
+        "fd_readdir": "__wasi_fd_readdir",
+        "fd_renumber": "__wasi_fd_renumber",
+        "fd_seek": "__wasi_fd_seek",
+        "fd_sync": "__wasi_fd_sync",
+        "fd_tell": "__wasi_fd_tell",
+        "fd_write": "__wasi_fd_write",
+        "path_create_directory": "__wasi_path_create_directory",
+        "path_filestat_get": "__wasi_path_filestat_get",
+        "path_filestat_set_times": "__wasi_path_filestat_set_times",
+        "path_link": "__wasi_path_link",
+        "path_open": "__wasi_path_open",
+        "path_readlink": "__wasi_path_readlink",
+        "path_remove_directory": "__wasi_path_remove_directory",
+        "path_rename": "__wasi_path_rename",
+        "path_symlink": "__wasi_path_symlink",
+        "path_unlink_file": "__wasi_path_unlink_file",
+        "poll_oneoff": "__wasi_poll_oneoff",
+        "proc_exit": "__wasi_proc_exit",
+        "random_get": "__wasi_random_get",
+        "sched_yield": "__wasi_sched_yield"
+    }
 }

--- a/assemblyscript/modules/wasa/package.json
+++ b/assemblyscript/modules/wasa/package.json
@@ -1,10 +1,9 @@
 {
   "scripts": {
-    "asbuild:untouched": "asc assembly/index.ts assembly/wasa.ts -b build/untouched.wasm",
-    "asbuild:small": "asc assembly/index.ts assembly/wasa.ts -b build/small.wasm -t build/small.wat -O3z",
-    "asbuild:optimized": "asc assembly/index.ts assembly/wasa.ts -b build/optimized.wasm -t build/optimized.wat -O3",
-    "asbuild": "npm run asbuild:optimized",
-    "test": "asp"
+    "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use abort=wasi_abort --debug",
+    "asbuild:small": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --use abort=wasi_abort --validate -O3z ",
+    "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --use abort=wasi_abort --validate -O3",
+    "asbuild": "npm run asbuild:optimized"
   },
   "devDependencies": {
     "as-pect": "github:jtenner/as-pect",


### PR DESCRIPTION
This is an update to the AssemblyScript module and example, after the new
runtimes landed into the AssemblyScript compiler.

WASA, the WASI bindings, got a major update, not only to support the new ASC,
but also to support most of WASI as it is today.
Breaking changes were made to the API to make is both safer and closer to the
NodeJS filesystem API.

wasm-crypto was updated for the new runtime as well.

The example was updated for the new runtime and the new WASA API.

The AssemblyScript compiler still has some rough edges regarding garbage
collection. So, switch the runtime from `full` (default) to `stub` for now,
until some known regressions have been ironed out.