### PR TITLE
lucetc::Lucetc::from_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "lucet-wasi-sdk 0.1.0",
  "lucetc 0.1.0",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,6 @@ dependencies = [
  "lucet-wasi-sdk 0.1.0",
  "lucetc 0.1.0",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -17,7 +17,7 @@ lucet-module-data = { path = "../../lucet-module-data" }
 lucet-runtime-internals = { path = "../lucet-runtime-internals" }
 lucet-wasi-sdk = { path = "../../lucet-wasi-sdk" }
 lucetc = { path = "../../lucetc" }
-
+wabt = "0.7"
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -17,7 +17,6 @@ lucet-module-data = { path = "../../lucet-module-data" }
 lucet-runtime-internals = { path = "../lucet-runtime-internals" }
 lucet-wasi-sdk = { path = "../../lucet-wasi-sdk" }
 lucetc = { path = "../../lucetc" }
-wabt = "0.7"
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -1,20 +1,16 @@
 use failure::Error;
 use lucet_runtime_internals::module::DlModule;
 use lucetc::Lucetc;
-use std::fs::File;
-use std::io::prelude::*;
 use std::sync::Arc;
 use tempfile::TempDir;
+use wabt::wat2wasm;
 
 pub fn stack_testcase(num_locals: usize) -> Result<Arc<DlModule>, Error> {
+    let wasm_program = wat2wasm(generate_test_wat(num_locals)).expect("test wat is valid");
+
+    let native_build = Lucetc::from_bytes(wasm_program);
+
     let workdir = TempDir::new().expect("create working directory");
-
-    let wasm_path = workdir.path().join("out.wasm");
-
-    let mut wasm_file = File::create(&wasm_path)?;
-    wasm_file.write_all(generate_test_wat(num_locals).as_bytes())?;
-
-    let native_build = Lucetc::new(wasm_path);
 
     let so_file = workdir.path().join("out.so");
 

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -3,12 +3,9 @@ use lucet_runtime_internals::module::DlModule;
 use lucetc::Lucetc;
 use std::sync::Arc;
 use tempfile::TempDir;
-use wabt::wat2wasm;
 
 pub fn stack_testcase(num_locals: usize) -> Result<Arc<DlModule>, Error> {
-    let wasm_program = wat2wasm(generate_test_wat(num_locals)).expect("test wat is valid");
-
-    let native_build = Lucetc::from_bytes(wasm_program);
+    let native_build = Lucetc::try_from_bytes(generate_test_wat(num_locals))?;
 
     let workdir = TempDir::new().expect("create working directory");
 

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -31,8 +31,13 @@ use std::env;
 use std::path::{Path, PathBuf};
 use tempfile;
 
+enum LucetcInput {
+    Bytes(Vec<u8>),
+    Path(PathBuf),
+}
+
 pub struct Lucetc {
-    input: PathBuf,
+    input: LucetcInput,
     bindings: Vec<Bindings>,
     opt_level: OptLevel,
     heap: HeapSettings,
@@ -150,7 +155,17 @@ impl Lucetc {
     pub fn new<P: AsRef<Path>>(input: P) -> Self {
         let input = input.as_ref();
         Self {
-            input: input.to_owned(),
+            input: LucetcInput::Path(input.to_owned()),
+            bindings: vec![],
+            opt_level: OptLevel::default(),
+            heap: HeapSettings::default(),
+            builtins_paths: vec![],
+        }
+    }
+
+    pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Self {
+        Self {
+            input: LucetcInput::Bytes(bytes.as_ref().to_owned()),
             bindings: vec![],
             opt_level: OptLevel::default(),
             heap: HeapSettings::default(),
@@ -162,7 +177,10 @@ impl Lucetc {
         use parity_wasm::elements::{deserialize_buffer, serialize};
 
         let mut builtins_bindings = vec![];
-        let mut module_binary = read_module(&self.input)?;
+        let mut module_binary = match &self.input {
+            LucetcInput::Bytes(bytes) => bytes.clone(),
+            LucetcInput::Path(path) => read_module(&path)?,
+        };
 
         if !self.builtins_paths.is_empty() {
             let mut module = deserialize_buffer(&module_binary)?;

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -181,7 +181,7 @@ impl Lucetc {
         let mut builtins_bindings = vec![];
         let mut module_binary = match &self.input {
             LucetcInput::Bytes(bytes) => bytes.clone(),
-            LucetcInput::Path(path) => read_module(path)?
+            LucetcInput::Path(path) => read_module(&path)?,
         };
 
         if !self.builtins_paths.is_empty() {

--- a/lucetc/src/load.rs
+++ b/lucetc/src/load.rs
@@ -7,10 +7,14 @@ use wabt::wat2wasm;
 
 pub fn read_module<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Error> {
     let contents = read_to_u8s(path)?;
-    let converted = if wasm_preamble(&contents) {
-        contents
+    read_bytes(contents)
+}
+
+pub fn read_bytes(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
+    let converted = if wasm_preamble(&bytes) {
+        bytes
     } else {
-        wat2wasm(contents).map_err(|_| {
+        wat2wasm(bytes).map_err(|_| {
             format_err!("Input is neither valid WASM nor WAT").context(LucetcErrorKind::Input)
         })?
     };


### PR DESCRIPTION
This takes care of #193. :smile_cat: 

Adds a `from_bytes<B: AsRef<[u8]>>(bytes: B)` method so that `lucetc::Lucetc` can be constructed from bytes. This means that we aren't required to write a program to disk in certain situations, if we already have the wasm binary content in memory.

`from_bytes` is used rather than a `from_path` because I didn't want to change the behavior of `new`.

While poking around at this I found that the stack tests in `lucet-runtime/lucet-runtime-tests/src/stack` were a good candidate to switch from `Lucetc::new` to `Lucet::from_bytes`, skipping the need to write the wat content generated by `generate_test_wat` to a file in the tempdir. :tada: 

p.s. big thanks & kudos to @awortman-fastly for helping me out getting started w/ this :tada: 