### PR TITLE
Update the shootout makefile to use the `fast` optimization level

### DIFF
--- a/benchmarks/shootout/Makefile
+++ b/benchmarks/shootout/Makefile
@@ -16,7 +16,7 @@ SHOOTOUT_SRCS:=$(shell ls $(SHOOTOUT)/*.c)
 SHOOTOUT_NATIVE_OBJS:=
 SHOOTOUT_LUCET_OBJS:=
 
-LUCETC_FLAGS:=--opt-level best --min-reserved-size 4294967296
+LUCETC_FLAGS:=--opt-level fast --min-reserved-size 4294967296
 COMMON_CFLAGS:=--std=c99 -Ofast -Wall -W -I$(SIGHTGLASS)/include
 
 SHOOTOUT_NATIVE_CFLAGS:=-march=native -fPIC \

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -37,7 +37,7 @@ impl Default for OptLevel {
 impl OptLevel {
     pub fn to_flag(&self) -> &str {
         match self {
-            OptLevel::None => "fast",
+            OptLevel::None => "fastest",
             OptLevel::Standard => "default",
             OptLevel::Fast => "best",
         }


### PR DESCRIPTION
`best` doesn't exist any more.

Fixes #216