### PR TITLE
Add flag to make wasm tables writable by the host

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -20,6 +20,21 @@ pub struct TableElement {
     rf: u64,
 }
 
+impl TableElement {
+    pub fn set_element(&mut self, new_ty: u64, new_rf: u64) {
+        self.ty = new_ty;
+        self.rf = new_rf;
+    }
+
+    pub fn ty(&self) -> u64 {
+        self.ty
+    }
+
+    pub fn rf(&self) -> u64 {
+        self.rf
+    }
+}
+
 /// Details about a program address.
 ///
 /// It is possible to determine whether an address lies within the module code if the module is
@@ -55,6 +70,8 @@ pub trait ModuleInternal: Send + Sync {
 
     /// Get the table elements from the module.
     fn table_elements(&self) -> Result<&[TableElement], Error>;
+
+    fn table_elements_mut(&self) -> Result<&mut [TableElement], Error>;
 
     fn get_export_func(&self, sym: &str) -> Result<FunctionHandle, Error>;
 

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -258,6 +258,10 @@ impl ModuleInternal for MockModule {
         Ok(&self.table_elements)
     }
 
+    fn table_elements_mut(&self) -> Result<&mut [TableElement], Error> {
+        Err(Error::Unsupported("Mutable elements not implemented".to_string()))
+    }
+
     fn get_export_func(&self, sym: &str) -> Result<FunctionHandle, Error> {
         let ptr = *self
             .export_funcs

--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -67,7 +67,7 @@ impl ScriptEnv {
     }
     pub fn instantiate(&mut self, module: &[u8], name: &Option<String>) -> Result<(), ScriptError> {
         let bindings = bindings::spec_test_bindings();
-        let compiler = Compiler::new(module, OptLevel::Fast, &bindings, HeapSettings::default())
+        let compiler = Compiler::new(module, OptLevel::Fast, &bindings, HeapSettings::default(), false /* writable_tables */)
             .map_err(program_error)?;
 
         let dir = tempfile::Builder::new().prefix("codegen").tempdir()?;

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -56,6 +56,7 @@ impl<'a> Compiler<'a> {
         opt_level: OptLevel,
         bindings: &Bindings,
         heap_settings: HeapSettings,
+        writable_tables: bool,
     ) -> Result<Self, LucetcError> {
         let isa = Self::target_isa(opt_level);
 
@@ -99,6 +100,7 @@ impl<'a> Compiler<'a> {
             bindings,
             runtime,
             heap_settings,
+            writable_tables,
         )?;
 
         Ok(Self {

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -82,9 +82,10 @@ impl<'a> ModuleDecls<'a> {
         bindings: &Bindings,
         runtime: Runtime,
         heap_settings: HeapSettings,
+        writable_tables: bool,
     ) -> Result<Self, LucetcError> {
         let imports: Vec<ImportFunction<'a>> = Vec::with_capacity(info.imported_funcs.len());
-        let table_names = Self::declare_tables(&info, clif_module)?;
+        let table_names = Self::declare_tables(&info, clif_module, writable_tables)?;
         let globals_spec = Self::build_globals_spec(&info)?;
         let linear_memory_spec = Self::build_linear_memory_spec(&info, heap_settings)?;
         let mut decls = Self {
@@ -203,12 +204,13 @@ impl<'a> ModuleDecls<'a> {
     fn declare_tables<B: ClifBackend>(
         info: &ModuleInfo<'a>,
         clif_module: &mut ClifModule<B>,
+        writable_tables : bool,
     ) -> Result<PrimaryMap<TableIndex, (Name, Name)>, LucetcError> {
         let mut table_names = PrimaryMap::new();
         for ix in 0..info.tables.len() {
             let def_symbol = format!("guest_table_{}", ix);
             let def_data_id = clif_module
-                .declare_data(&def_symbol, Linkage::Export, false)
+                .declare_data(&def_symbol, Linkage::Export, writable_tables)
                 .context(LucetcErrorKind::TranslatingModule)?;
             let def_name = Name::new_data(def_symbol, def_data_id);
 

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -43,6 +43,7 @@ pub struct Lucetc {
     opt_level: OptLevel,
     heap: HeapSettings,
     builtins_paths: Vec<PathBuf>,
+    writable_tables: bool
 }
 
 pub trait AsLucetc {
@@ -82,6 +83,9 @@ pub trait LucetcOpts {
 
     fn guard_size(&mut self, guard_size: u64);
     fn with_guard_size(self, guard_size: u64) -> Self;
+
+    fn writable_tables(&mut self, writable_tables: bool);
+    fn with_writable_tables(self, writable_tables: bool) -> Self;
 }
 
 impl<T: AsLucetc> LucetcOpts for T {
@@ -150,6 +154,15 @@ impl<T: AsLucetc> LucetcOpts for T {
         self.guard_size(guard_size);
         self
     }
+
+    fn writable_tables(&mut self, writable_tables: bool) {
+        self.as_lucetc().writable_tables = writable_tables;
+    }
+
+    fn with_writable_tables(mut self, writable_tables: bool) -> Self {
+        self.writable_tables(writable_tables);
+        self
+    }
 }
 
 impl Lucetc {
@@ -161,6 +174,7 @@ impl Lucetc {
             opt_level: OptLevel::default(),
             heap: HeapSettings::default(),
             builtins_paths: vec![],
+            writable_tables : false
         }
     }
 
@@ -172,6 +186,7 @@ impl Lucetc {
             opt_level: OptLevel::default(),
             heap: HeapSettings::default(),
             builtins_paths: vec![],
+            writable_tables: false
         })
     }
 
@@ -211,6 +226,7 @@ impl Lucetc {
             self.opt_level,
             &bindings,
             self.heap.clone(),
+            self.writable_tables,
         )?;
         let obj = compiler.object_file()?;
 
@@ -226,6 +242,7 @@ impl Lucetc {
             self.opt_level,
             &bindings,
             self.heap.clone(),
+            self.writable_tables,
         )?;
 
         compiler

--- a/lucetc/src/main.rs
+++ b/lucetc/src/main.rs
@@ -67,6 +67,8 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         c.guard_size(guard_size);
     }
 
+    c.writable_tables(opts.writable_tables);
+
     match opts.codegen {
         CodegenOutput::Obj => c.object_file(&opts.output)?,
         CodegenOutput::SharedObj => c.shared_object_file(&opts.output)?,

--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -41,6 +41,7 @@ pub struct Options {
     pub reserved_size: Option<u64>,
     pub guard_size: Option<u64>,
     pub opt_level: OptLevel,
+    pub writable_tables : bool,
 }
 
 impl Options {
@@ -101,6 +102,8 @@ impl Options {
             Some(_) => panic!("unknown value for opt-level"),
         };
 
+        let writable_tables = m.is_present("writable_tables");
+
         Ok(Options {
             output,
             input,
@@ -112,6 +115,7 @@ impl Options {
             reserved_size,
             guard_size,
             opt_level,
+            writable_tables
         })
     }
     pub fn get() -> Result<Self, Error> {
@@ -197,6 +201,12 @@ impl Options {
                     .takes_value(true)
                     .possible_values(&["0", "1", "2", "fast"])
                     .help("optimization level (default: '1')"),
+            )
+            .arg(
+                Arg::with_name("writable_tables")
+                    .long("--writable-tables")
+                    .takes_value(false)
+                    .help("make the function indirection tables writable"),
             )
             .get_matches();
 


### PR DESCRIPTION
Per https://github.com/WebAssembly/design/issues/1117, the wasm tables are modifiable by the host. However, lucet is currently emitting these tables as read only ELF sections. 

This PR makes these tables writable (This is hidden behind a flag "--writable-tables" for now)

*Use Case*
I am a PhD student working with Mozilla to look at the using WASM (with the WASI backend) to sandbox libraries used in the Firefox codebase. However, in our use case, the host can dynamically decide which host functions are callable by the wasm module. Thus the inability to modify the tables is blocking. 

I had a brief conversation with iximeow on the Mozilla IRC who suggested I open a PR to start a discussion. Please let me know if you have thoughts or require more detail etc.