### PR TITLE
Allow creating UntypedRetVal

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/val.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/val.rs
@@ -176,6 +176,21 @@ impl UntypedRetVal {
     }
 }
 
+impl From<RegVal> for UntypedRetVal {
+    fn from(reg: RegVal) -> UntypedRetVal {
+        match reg {
+            RegVal::GpReg(r) => UntypedRetVal::new(r, unsafe { _mm_setzero_ps() }),
+            RegVal::FpReg(r) => UntypedRetVal::new(0, r),
+        }
+    }
+}
+
+impl<T: Into<Val>> From<T> for UntypedRetVal {
+    fn from(v: T) -> UntypedRetVal {
+        val_to_reg(&v.into()).into()
+    }
+}
+
 macro_rules! impl_from_fp {
     ( $ty:ty, $f:ident, $as:ident ) => {
         impl From<UntypedRetVal> for $ty {

--- a/lucet-runtime/tests/val.rs
+++ b/lucet-runtime/tests/val.rs
@@ -1,0 +1,61 @@
+use lucet_runtime_internals::val::UntypedRetVal;
+
+#[test]
+fn untyped_ret_val_from_f32() {
+    assert_eq!(1.2, f32::from(UntypedRetVal::from(1.2f32)));
+}
+
+#[test]
+fn untyped_ret_val_from_f64() {
+    assert_eq!(1.2, f64::from(UntypedRetVal::from(1.2f64)));
+}
+
+#[test]
+fn untyped_ret_val_from_u8() {
+    assert_eq!(5, u8::from(UntypedRetVal::from(5u8)));
+}
+
+#[test]
+fn untyped_ret_val_from_u16() {
+    assert_eq!(5, u16::from(UntypedRetVal::from(5u16)));
+}
+
+#[test]
+fn untyped_ret_val_from_u32() {
+    assert_eq!(5, u32::from(UntypedRetVal::from(5u32)));
+}
+
+#[test]
+fn untyped_ret_val_from_u64() {
+    assert_eq!(5, u64::from(UntypedRetVal::from(5u64)));
+}
+
+#[test]
+fn untyped_ret_val_from_i8() {
+    assert_eq!(5, i8::from(UntypedRetVal::from(5i8)));
+}
+
+#[test]
+fn untyped_ret_val_from_i16() {
+    assert_eq!(5, i16::from(UntypedRetVal::from(5i16)));
+}
+
+#[test]
+fn untyped_ret_val_from_i32() {
+    assert_eq!(5, i32::from(UntypedRetVal::from(5i32)));
+}
+
+#[test]
+fn untyped_ret_val_from_i64() {
+    assert_eq!(5, i64::from(UntypedRetVal::from(5i64)));
+}
+
+#[test]
+fn untyped_ret_val_from_bool_true() {
+    assert_eq!(true, bool::from(UntypedRetVal::from(true)));
+}
+
+#[test]
+fn untyped_ret_val_from_bool_false() {
+    assert_eq!(false, bool::from(UntypedRetVal::from(false)));
+}


### PR DESCRIPTION
This allows only creating it from values that can be fully safely represented.
The reason to do this is for writing tests in downstream crates that want to
test what is done with the result of a guest run.

Closes #211