### PR TITLE
Add a helper script to set the global package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+# Lucet version 0.1.0
+
 [workspace]
 members = [
   "lucet-analyze",

--- a/helpers/bump-global-version.sh
+++ b/helpers/bump-global-version.sh
@@ -1,0 +1,27 @@
+#! /bin/sh
+
+VERSION=$(grep '#*Lucet version ' Cargo.toml | sed 's/^ *# Lucet version *//')
+[ -z "$VERSION" ] && echo "Version header not found in the top Cargo.toml file" >&2 && exit 1
+
+dry_run() {
+    echo "Checking if the package can be published (dry run)..."
+    echo
+    find lucetc lucet-* benchmarks/lucet-* -type f -maxdepth 1 -name 'Cargo.toml' -print | while read -r file; do
+        dir="$(dirname $file)"
+        echo "* Checking [$dir]"
+        (cd "$dir" && cargo publish --allow-dirty --dry-run >/dev/null) || exit 1
+    done || exit 1
+    echo
+    echo "Done."
+}
+
+version_bump() {
+    echo
+    echo "Setting the global Lucet version number to: [$VERSION]"
+    find lucetc lucet-* benchmarks/lucet-* -type f -maxdepth 1 -name 'Cargo.toml' -print | while read -r file; do
+        sed -i '' "s/^ *version *=.*/version = \"${VERSION}\"/" "$file"
+    done
+    echo "Done."
+}
+
+dry_run && version_bump && dry_run

--- a/helpers/bump-global-version.sh
+++ b/helpers/bump-global-version.sh
@@ -19,7 +19,7 @@ version_bump() {
     echo
     echo "Setting the global Lucet version number to: [$VERSION]"
     find lucetc lucet-* benchmarks/lucet-* -type f -maxdepth 1 -name 'Cargo.toml' -print | while read -r file; do
-        sed -i '' "s/^ *version *=.*/version = \"${VERSION}\"/" "$file"
+        sed -i '.previous' "s/^ *version *=.*/version = \"${VERSION}\"/" "$file" && rm -f "${file}.previous"
     done
     echo "Done."
 }


### PR DESCRIPTION
Check that in their current state, subpackages can be published.

Only then, set the global version number to the same as the main Cargo.toml file

Then, try one last dry run with the new version number.