### PR TITLE
lucet-idl: delete attrs

### DIFF
--- a/lucet-idl/src/data_layout.rs
+++ b/lucet-idl/src/data_layout.rs
@@ -1,14 +1,13 @@
 use crate::error::ValidationError;
 use crate::types::{
-    AliasDataType, AtomType, Attr, DataType, DataTypeRef, DataTypeVariant, EnumDataType,
-    EnumMember, Ident, Location, Name, StructDataType, StructMember,
+    AliasDataType, AtomType, DataType, DataTypeRef, DataTypeVariant, EnumDataType, EnumMember,
+    Ident, Location, Name, StructDataType, StructMember,
 };
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 struct DataTypeIR {
     pub variant: VariantIR,
-    pub attrs: Vec<Attr>,
     pub location: Location,
 }
 
@@ -16,7 +15,6 @@ struct DataTypeIR {
 pub struct StructMemberIR {
     pub type_: DataTypeRef,
     pub name: String,
-    pub attrs: Vec<Attr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -53,12 +51,11 @@ impl DataTypeModuleBuilder {
         }
     }
 
-    pub fn define(&mut self, id: Ident, variant: VariantIR, attrs: Vec<Attr>, location: Location) {
+    pub fn define(&mut self, id: Ident, variant: VariantIR, location: Location) {
         if let Some(prev_def) = self.data_types.insert(
             id,
             DataTypeIR {
                 variant,
-                attrs: attrs.clone(),
                 location: location.clone(),
             },
         ) {
@@ -104,7 +101,6 @@ impl DataTypeModuleBuilder {
                         members.push(StructMember {
                             type_: mem.type_.clone(),
                             name: mem.name.clone(),
-                            attrs: mem.attrs.clone(),
                             offset,
                         });
                         offset += repr_size;
@@ -116,7 +112,6 @@ impl DataTypeModuleBuilder {
                         id,
                         DataType {
                             variant: DataTypeVariant::Struct(StructDataType { members }),
-                            attrs: dt.attrs.clone(),
                             repr_size,
                             align: struct_align,
                         },
@@ -134,7 +129,6 @@ impl DataTypeModuleBuilder {
                         id,
                         DataType {
                             variant: DataTypeVariant::Alias(AliasDataType { to: a.to.clone() }),
-                            attrs: dt.attrs.clone(),
                             repr_size,
                             align,
                         },
@@ -153,7 +147,6 @@ impl DataTypeModuleBuilder {
                             variant: DataTypeVariant::Enum(EnumDataType {
                                 members: e.members.clone(),
                             }),
-                            attrs: dt.attrs.clone(),
                             repr_size,
                             align,
                         },

--- a/lucet-idl/src/lib.rs
+++ b/lucet-idl/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::error::IDLError;
 pub use crate::module::Module;
 pub use crate::package::Package;
 pub use crate::types::{
-    AliasDataType, AtomType, Attr, DataType, DataTypeRef, DataTypeVariant, EnumDataType, FuncDecl,
+    AliasDataType, AtomType, DataType, DataTypeRef, DataTypeVariant, EnumDataType, FuncDecl,
     FuncRet, Ident, Location, Name, Named, StructDataType, StructMember,
 };
 

--- a/lucet-idl/src/module.rs
+++ b/lucet-idl/src/module.rs
@@ -310,7 +310,7 @@ mod tests {
     fn mod_(syntax: &str) -> Result<Module, ValidationError> {
         let mut parser = Parser::new(syntax);
         let decls = parser.match_decls().expect("parses");
-        Module::from_declarations(&decls, &[], String::new(), String::new())
+        Module::from_declarations(&decls, String::new(), String::new())
     }
 
     #[test]

--- a/lucet-idl/src/package.rs
+++ b/lucet-idl/src/package.rs
@@ -77,13 +77,11 @@ impl Package {
 
         for (decl, id) in decls.iter().zip(&idents) {
             match decl {
-                SyntaxDecl::Module {
-                    decls, attrs, name, ..
-                } => {
+                SyntaxDecl::Module { decls, name, .. } => {
                     let binding_prefix = "__".to_owned() + &name.to_snake_case();
                     pkg.define_module(
                         *id,
-                        Module::from_declarations(decls, attrs, name.clone(), binding_prefix)?,
+                        Module::from_declarations(decls, name.clone(), binding_prefix)?,
                     );
                 }
                 _ => unreachable!(),
@@ -130,7 +128,6 @@ mod test {
                 Ident(0),
                 Module {
                     names: Vec::new(),
-                    attrs: Vec::new(),
                     data_types: HashMap::new(),
                     data_type_ordering: Vec::new(),
                     funcs: HashMap::new(),
@@ -176,7 +173,6 @@ mod test {
                     Ident(0),
                     Module {
                         names: Vec::new(),
-                        attrs: Vec::new(),
                         data_types: HashMap::new(),
                         data_type_ordering: Vec::new(),
                         funcs: HashMap::new(),
@@ -188,7 +184,6 @@ mod test {
                     Ident(1),
                     Module {
                         names: Vec::new(),
-                        attrs: Vec::new(),
                         data_types: HashMap::new(),
                         data_type_ordering: Vec::new(),
                         funcs: HashMap::new(),
@@ -200,7 +195,6 @@ mod test {
                     Ident(2),
                     Module {
                         names: Vec::new(),
-                        attrs: Vec::new(),
                         data_types: HashMap::new(),
                         data_type_ordering: Vec::new(),
                         funcs: HashMap::new(),
@@ -236,7 +230,6 @@ mod test {
                             column: 10
                         }
                     }],
-                    attrs: Vec::new(),
                     funcs: HashMap::new(),
                     data_types: vec![(
                         Ident(0),
@@ -244,7 +237,6 @@ mod test {
                             variant: DataTypeVariant::Alias(AliasDataType {
                                 to: DataTypeRef::Atom(AtomType::U8)
                             }),
-                            attrs: Vec::new(),
                             repr_size: 1,
                             align: 1,
                         }

--- a/lucet-idl/src/parser.rs
+++ b/lucet-idl/src/parser.rs
@@ -204,9 +204,6 @@ impl<'a> Parser<'a> {
                     self.consume();
                     break;
                 }
-                Some(Token::Hash) => {
-                    self.consume();
-                }
                 Some(Token::Word(member_name)) => {
                     let location = self.location;
                     self.consume();
@@ -246,9 +243,6 @@ impl<'a> Parser<'a> {
                     self.consume();
                     break;
                 }
-                Some(Token::Hash) => {
-                    self.consume();
-                }
                 Some(Token::Word(name)) => {
                     let location = self.location;
                     self.consume();
@@ -281,9 +275,6 @@ impl<'a> Parser<'a> {
                 Some(Token::RPar) => {
                     self.consume();
                     break;
-                }
-                Some(Token::Hash) => {
-                    self.consume();
                 }
                 Some(Token::Word(name)) => {
                     let location = self.location;
@@ -321,9 +312,6 @@ impl<'a> Parser<'a> {
                 Some(Token::Semi) => {
                     self.consume();
                     break;
-                }
-                Some(Token::Hash) => {
-                    self.consume();
                 }
                 _ => {
                     let location = self.location;
@@ -444,10 +432,6 @@ impl<'a> Parser<'a> {
                         rets,
                         location,
                     }));
-                }
-                Some(Token::Hash) => {
-                    self.consume();
-                    continue;
                 }
                 Some(_) => {
                     return parse_err!(

--- a/lucet-idl/src/parser.rs
+++ b/lucet-idl/src/parser.rs
@@ -1,5 +1,5 @@
 use super::lexer::{LexError, Lexer, LocatedError, LocatedToken, Token};
-use super::types::{AtomType, Attr, Location};
+use super::types::{AtomType, Location};
 use std::error::Error;
 use std::fmt;
 
@@ -8,32 +8,27 @@ pub enum SyntaxDecl {
     Struct {
         name: String,
         members: Vec<StructMember>,
-        attrs: Vec<Attr>,
         location: Location,
     },
     Enum {
         name: String,
         variants: Vec<EnumVariant>,
-        attrs: Vec<Attr>,
         location: Location,
     },
     Alias {
         name: String,
         what: SyntaxRef,
-        attrs: Vec<Attr>,
         location: Location,
     },
     Module {
         name: String,
         decls: Vec<SyntaxDecl>,
-        attrs: Vec<Attr>,
         location: Location,
     },
     Function {
         name: String,
         args: Vec<FuncArgSyntax>,
         rets: Vec<FuncRetSyntax>,
-        attrs: Vec<Attr>,
         location: Location,
     },
 }
@@ -75,14 +70,12 @@ pub enum SyntaxRef {
 pub struct StructMember {
     pub name: String,
     pub type_: SyntaxRef,
-    pub attrs: Vec<Attr>,
     pub location: Location,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnumVariant {
     pub name: String,
-    pub attrs: Vec<Attr>,
     pub location: Location,
 }
 
@@ -90,14 +83,12 @@ pub struct EnumVariant {
 pub struct FuncArgSyntax {
     pub name: String,
     pub type_: SyntaxRef,
-    pub attrs: Vec<Attr>,
     pub location: Location,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FuncRetSyntax {
     pub type_: SyntaxRef,
-    pub attrs: Vec<Attr>,
     pub location: Location,
 }
 
@@ -205,24 +196,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn match_attr_body(&mut self) -> Result<Attr, ParseError> {
-        let location = self.location;
-        self.match_token(Token::LBracket, "expected attribute start [")?;
-        let key = self.match_a_word("expected attribute key")?;
-        self.match_token(Token::Equals, "expected =")?;
-        let val = match self.token() {
-            Some(Token::Word(text)) => text,
-            Some(Token::Quote(text)) => text,
-            _ => parse_err!(self.location, "expected word or quoted string")?,
-        };
-        self.consume();
-        self.match_token(Token::RBracket, "expected ]")?;
-        Ok(Attr::new(key, val, location))
-    }
-
     fn match_struct_body(&mut self) -> Result<Vec<StructMember>, ParseError> {
         let mut members = Vec::new();
-        let mut attrs = Vec::new();
         loop {
             match self.token() {
                 Some(Token::RBrace) => {
@@ -231,7 +206,6 @@ impl<'a> Parser<'a> {
                 }
                 Some(Token::Hash) => {
                     self.consume();
-                    attrs.push(self.match_attr_body()?);
                 }
                 Some(Token::Word(member_name)) => {
                     let location = self.location;
@@ -241,10 +215,8 @@ impl<'a> Parser<'a> {
                     members.push(StructMember {
                         name: member_name.to_string(),
                         type_: member_ref,
-                        attrs: attrs.clone(),
                         location,
                     });
-                    attrs.clear();
                     match self.token() {
                         Some(Token::Comma) => {
                             self.consume();
@@ -268,7 +240,6 @@ impl<'a> Parser<'a> {
 
     fn match_enum_body(&mut self) -> Result<Vec<EnumVariant>, ParseError> {
         let mut names = Vec::new();
-        let mut attrs = Vec::new();
         loop {
             match self.token() {
                 Some(Token::RBrace) => {
@@ -277,17 +248,14 @@ impl<'a> Parser<'a> {
                 }
                 Some(Token::Hash) => {
                     self.consume();
-                    attrs.push(self.match_attr_body()?);
                 }
                 Some(Token::Word(name)) => {
                     let location = self.location;
                     self.consume();
                     names.push(EnumVariant {
                         name: name.to_owned(),
-                        attrs: attrs.clone(),
                         location,
                     });
-                    attrs.clear();
                     match self.token() {
                         Some(Token::Comma) => {
                             self.consume();
@@ -303,15 +271,11 @@ impl<'a> Parser<'a> {
                 _ => parse_err!(self.location, "expected variant")?,
             }
         }
-        if !attrs.is_empty() {
-            parse_err!(self.location, "attributes unattached to an enum variant")?
-        }
         Ok(names)
     }
 
     fn match_func_args(&mut self) -> Result<Vec<FuncArgSyntax>, ParseError> {
         let mut args = Vec::new();
-        let mut attrs = Vec::new();
         loop {
             match self.token() {
                 Some(Token::RPar) => {
@@ -320,7 +284,6 @@ impl<'a> Parser<'a> {
                 }
                 Some(Token::Hash) => {
                     self.consume();
-                    attrs.push(self.match_attr_body()?);
                 }
                 Some(Token::Word(name)) => {
                     let location = self.location;
@@ -331,10 +294,8 @@ impl<'a> Parser<'a> {
                     args.push(FuncArgSyntax {
                         name: name.to_string(),
                         type_: type_ref,
-                        attrs: attrs.clone(),
                         location,
                     });
-                    attrs.clear();
                     match self.token() {
                         Some(Token::Comma) => {
                             self.consume();
@@ -350,18 +311,11 @@ impl<'a> Parser<'a> {
                 _ => parse_err!(self.location, "expected argument, or )")?,
             }
         }
-        if !attrs.is_empty() {
-            parse_err!(
-                self.location,
-                "attributes unattached to a function argument"
-            )?
-        }
         Ok(args)
     }
 
     fn match_func_rets(&mut self) -> Result<Vec<FuncRetSyntax>, ParseError> {
         let mut args = Vec::new();
-        let mut attrs = Vec::new();
         loop {
             match self.token() {
                 Some(Token::Semi) => {
@@ -370,17 +324,14 @@ impl<'a> Parser<'a> {
                 }
                 Some(Token::Hash) => {
                     self.consume();
-                    attrs.push(self.match_attr_body()?);
                 }
                 _ => {
                     let location = self.location;
                     let type_ref = self.match_ref("expected type, attribute, or ;")?;
                     args.push(FuncRetSyntax {
                         type_: type_ref,
-                        attrs: attrs.clone(),
                         location,
                     });
-                    attrs.clear();
                     match self.token() {
                         Some(Token::Comma) => {
                             self.consume();
@@ -395,17 +346,10 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        if !attrs.is_empty() {
-            parse_err!(
-                self.location,
-                "attributes unattached to a function return type"
-            )?
-        }
         Ok(args)
     }
 
     pub fn match_decl(&mut self, err_msg: &str) -> Result<Option<SyntaxDecl>, ParseError> {
-        let mut attrs = Vec::new();
         loop {
             match self.token() {
                 Some(Token::Word("struct")) => {
@@ -417,7 +361,6 @@ impl<'a> Parser<'a> {
                     return Ok(Some(SyntaxDecl::Struct {
                         name: name.to_owned(),
                         members,
-                        attrs,
                         location,
                     }));
                 }
@@ -430,7 +373,6 @@ impl<'a> Parser<'a> {
                     return Ok(Some(SyntaxDecl::Enum {
                         name: name.to_owned(),
                         variants,
-                        attrs,
                         location,
                     }));
                 }
@@ -444,7 +386,6 @@ impl<'a> Parser<'a> {
                     return Ok(Some(SyntaxDecl::Alias {
                         name: name.to_owned(),
                         what,
-                        attrs,
                         location,
                     }));
                 }
@@ -471,7 +412,6 @@ impl<'a> Parser<'a> {
                     return Ok(Some(SyntaxDecl::Module {
                         name: name.to_owned(),
                         decls,
-                        attrs,
                         location,
                     }));
                 }
@@ -502,13 +442,11 @@ impl<'a> Parser<'a> {
                         name: name.to_owned(),
                         args,
                         rets,
-                        attrs,
                         location,
                     }));
                 }
                 Some(Token::Hash) => {
                     self.consume();
-                    attrs.push(self.match_attr_body()?);
                     continue;
                 }
                 Some(_) => {
@@ -519,9 +457,6 @@ impl<'a> Parser<'a> {
                     )
                 }
                 None => {
-                    if !attrs.is_empty() {
-                        parse_err!(self.location, "attributes unattached to a declaration")?
-                    }
                     return Ok(None);
                 }
             }
@@ -577,7 +512,6 @@ mod tests {
             SyntaxDecl::Struct {
                 name: "foo".to_string(),
                 members: Vec::new(),
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -602,13 +536,11 @@ mod tests {
                             column: 15,
                         },
                     },
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 12,
                     },
                 }],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -633,13 +565,11 @@ mod tests {
                             column: 15,
                         },
                     },
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 12,
                     },
                 }],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -665,7 +595,6 @@ mod tests {
                                 column: 14,
                             },
                         },
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 11,
@@ -680,100 +609,12 @@ mod tests {
                                 column: 22,
                             },
                         },
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 19,
                         },
                     },
                 ],
-                attrs: Vec::new(),
-                location: Location { line: 1, column: 0 },
-            }
-        );
-    }
-    #[test]
-    fn struct_empty_one_attribute() {
-        // Test out attributes:
-        let mut parser = Parser::new("#[key1=val1] struct foo {}");
-        assert_eq!(
-            parser
-                .match_decl("empty struct")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Struct {
-                name: "foo".to_string(),
-                members: Vec::new(),
-                attrs: vec![Attr::new("key1", "val1", Location { line: 1, column: 0 })],
-                location: Location {
-                    line: 1,
-                    column: 13,
-                },
-            }
-        );
-    }
-    #[test]
-    fn struct_empty_one_attribute_with_spaces() {
-        let mut parser = Parser::new("#[key2=\"1 value with spaces!\"]\nstruct foo {}");
-        assert_eq!(
-            parser
-                .match_decl("empty struct")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Struct {
-                name: "foo".to_string(),
-                members: Vec::new(),
-                attrs: vec![Attr::new(
-                    "key2",
-                    "1 value with spaces!",
-                    Location { line: 1, column: 0 },
-                )],
-                location: Location { line: 2, column: 0 },
-            }
-        );
-    }
-    #[test]
-    fn struct_empty_multiple_attributes() {
-        let mut parser = Parser::new("#[key1=val1]\n\t#[key2 = \"val2\"   ]\nstruct foo {}");
-        assert_eq!(
-            parser
-                .match_decl("empty struct")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Struct {
-                name: "foo".to_string(),
-                members: Vec::new(),
-                attrs: vec![
-                    Attr::new("key1", "val1", Location { line: 1, column: 0 }),
-                    Attr::new("key2", "val2", Location { line: 2, column: 8 }),
-                ],
-                location: Location { line: 3, column: 0 },
-            }
-        );
-    }
-    #[test]
-    fn struct_member_attribute() {
-        let mut parser = Parser::new("struct foo {\n\t#[key=val]\n\tmem: f32,\n}");
-        assert_eq!(
-            parser
-                .match_decl("empty struct")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Struct {
-                name: "foo".to_string(),
-                members: vec![StructMember {
-                    name: "mem".to_owned(),
-                    type_: SyntaxRef::Atom {
-                        atom: AtomType::F32,
-                        location: Location {
-                            line: 3,
-                            column: 13,
-                        },
-                    },
-                    attrs: vec![Attr::new("key", "val", Location { line: 2, column: 8 })],
-                    location: Location { line: 3, column: 8 },
-                }],
-                attrs: Vec::new(), //
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -800,7 +641,6 @@ mod tests {
                                 column: 15,
                             },
                         },
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 12,
@@ -815,14 +655,12 @@ mod tests {
                                 column: 28,
                             },
                         },
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 20,
                         },
                     }
                 ],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -839,7 +677,6 @@ mod tests {
             SyntaxDecl::Enum {
                 name: "foo".to_owned(),
                 variants: Vec::new(),
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             },
         );
@@ -857,13 +694,11 @@ mod tests {
                 name: "foo".to_owned(),
                 variants: vec![EnumVariant {
                     name: "first".to_owned(),
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 10,
                     },
                 }],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             },
         );
@@ -881,60 +716,16 @@ mod tests {
                 name: "bar".to_owned(),
                 variants: vec![EnumVariant {
                     name: "first".to_owned(),
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 10,
                     },
                 }],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             },
         );
     }
-    #[test]
-    fn enum_one_entry_with_attr() {
-        let mut parser = Parser::new("enum bar { #[a=b] first}");
-        //                            0    5    10
-        assert_eq!(
-            parser
-                .match_decl("one entry enum, no trailing comma")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Enum {
-                name: "bar".to_owned(),
-                variants: vec![EnumVariant {
-                    name: "first".to_owned(),
-                    attrs: vec![Attr::new(
-                        "a",
-                        "b",
-                        Location {
-                            line: 1,
-                            column: 11
-                        }
-                    ),],
-                    location: Location {
-                        line: 1,
-                        column: 18,
-                    },
-                }],
-                attrs: Vec::new(),
-                location: Location { line: 1, column: 0 },
-            },
-        );
-    }
-    #[test]
-    fn enum_one_entry_trailing_attr() {
-        assert!(Parser::new("enum bar { #[a=b] first, #[c=d] }")
-            .match_decl("one entry enum")
-            .is_err());
-    }
-    #[test]
-    fn enum_no_entry_attr() {
-        assert!(Parser::new("enum bar { #[c=d] }")
-            .match_decl("zero entry enum")
-            .is_err());
-    }
+
     #[test]
     fn enum_four_entry() {
         let mut parser = Parser::new("enum baz { one, two, three\n, four, }");
@@ -949,7 +740,6 @@ mod tests {
                 variants: vec![
                     EnumVariant {
                         name: "one".to_owned(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 11,
@@ -957,7 +747,6 @@ mod tests {
                     },
                     EnumVariant {
                         name: "two".to_owned(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 16,
@@ -965,7 +754,6 @@ mod tests {
                     },
                     EnumVariant {
                         name: "three".to_owned(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 21,
@@ -973,11 +761,9 @@ mod tests {
                     },
                     EnumVariant {
                         name: "four".to_owned(),
-                        attrs: Vec::new(),
                         location: Location { line: 2, column: 2 },
                     },
                 ],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             },
         );
@@ -995,7 +781,6 @@ mod tests {
             SyntaxDecl::Module {
                 name: "empty".to_owned(),
                 decls: Vec::new(),
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -1017,19 +802,16 @@ mod tests {
                     decls: vec![SyntaxDecl::Module {
                         name: "three".to_owned(),
                         decls: Vec::new(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 20
                         },
                     }],
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 10
                     },
                 }],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );
@@ -1050,7 +832,6 @@ mod tests {
                     SyntaxDecl::Enum {
                         name: "foo".to_owned(),
                         variants: Vec::new(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 10
@@ -1059,59 +840,13 @@ mod tests {
                     SyntaxDecl::Struct {
                         name: "bar".to_owned(),
                         members: Vec::new(),
-                        attrs: Vec::new(),
                         location: Location {
                             line: 1,
                             column: 22
                         },
                     }
                 ],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
-            }
-        );
-    }
-
-    #[test]
-    fn mod_attrs() {
-        let mut parser = Parser::new("#[a=b]\nmod one { #[c=d] enum foo {} struct bar {} }");
-        //                                    0    5    10   15   20   25   30
-        assert_eq!(
-            parser
-                .match_decl("module with types")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Module {
-                name: "one".to_owned(),
-                decls: vec![
-                    SyntaxDecl::Enum {
-                        name: "foo".to_owned(),
-                        variants: Vec::new(),
-                        attrs: vec![Attr::new(
-                            "c",
-                            "d",
-                            Location {
-                                line: 2,
-                                column: 10
-                            }
-                        ),],
-                        location: Location {
-                            line: 2,
-                            column: 17
-                        },
-                    },
-                    SyntaxDecl::Struct {
-                        name: "bar".to_owned(),
-                        members: Vec::new(),
-                        attrs: Vec::new(),
-                        location: Location {
-                            line: 2,
-                            column: 29
-                        },
-                    }
-                ],
-                attrs: vec![Attr::new("a", "b", Location { line: 1, column: 0 }),],
-                location: Location { line: 2, column: 0 },
             }
         );
     }
@@ -1122,7 +857,6 @@ mod tests {
             name: "trivial".to_owned(),
             args: Vec::new(),
             rets: Vec::new(),
-            attrs: Vec::new(),
             location: Location { line: 1, column: 0 },
         }];
         assert_eq!(
@@ -1161,13 +895,11 @@ mod tests {
                         column: 14,
                     },
                 },
-                attrs: vec![],
                 location: Location {
                     line: 1,
                     column: 14,
                 },
             }],
-            attrs: Vec::new(),
             location: Location { line: 1, column: 0 },
         }];
         assert_eq!(
@@ -1206,11 +938,9 @@ mod tests {
                     },
                 },
                 name: "a".to_owned(),
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 7 },
             }],
             rets: Vec::new(),
-            attrs: Vec::new(),
             location: Location { line: 1, column: 0 },
         };
         assert_eq!(
@@ -1245,7 +975,6 @@ mod tests {
                         },
                     },
                     name: "a".to_owned(),
-                    attrs: Vec::new(),
                     location: Location { line: 1, column: 7 },
                 },
                 FuncArgSyntax {
@@ -1257,7 +986,6 @@ mod tests {
                         },
                     },
                     name: "b".to_owned(),
-                    attrs: Vec::new(),
                     location: Location {
                         line: 1,
                         column: 14,
@@ -1265,7 +993,6 @@ mod tests {
                 },
             ],
             rets: Vec::new(),
-            attrs: Vec::new(),
             location: Location { line: 1, column: 0 },
         };
         assert_eq!(
@@ -1306,7 +1033,6 @@ mod tests {
                                 column: 14,
                             },
                         },
-                        attrs: vec![],
                         location: Location {
                             line: 1,
                             column: 14,
@@ -1320,7 +1046,6 @@ mod tests {
                                 column: 18,
                             },
                         },
-                        attrs: vec![],
                         location: Location {
                             line: 1,
                             column: 18,
@@ -1334,99 +1059,12 @@ mod tests {
                                 column: 23,
                             },
                         },
-                        attrs: vec![],
                         location: Location {
                             line: 1,
                             column: 23,
                         },
                     },
                 ],
-                attrs: Vec::new(),
-                location: Location { line: 1, column: 0 },
-            }
-        );
-    }
-
-    #[test]
-    fn fn_many_returns_with_attrs() {
-        assert_eq!(
-            Parser::new("fn getch() -> #[a=b] u8, #[c=d] #[e=f] u16, u32;")
-                //       0    5    10   15   20   25   30   35   40   45
-                .match_decl("returns u8")
-                .expect("valid parse")
-                .expect("valid decl"),
-            SyntaxDecl::Function {
-                name: "getch".to_owned(),
-                args: Vec::new(),
-                rets: vec![
-                    FuncRetSyntax {
-                        type_: SyntaxRef::Atom {
-                            atom: AtomType::U8,
-                            location: Location {
-                                line: 1,
-                                column: 21,
-                            },
-                        },
-                        attrs: vec![Attr::new(
-                            "a",
-                            "b",
-                            Location {
-                                line: 1,
-                                column: 14
-                            }
-                        )],
-                        location: Location {
-                            line: 1,
-                            column: 21,
-                        },
-                    },
-                    FuncRetSyntax {
-                        type_: SyntaxRef::Atom {
-                            atom: AtomType::U16,
-                            location: Location {
-                                line: 1,
-                                column: 39,
-                            },
-                        },
-                        attrs: vec![
-                            Attr::new(
-                                "c",
-                                "d",
-                                Location {
-                                    line: 1,
-                                    column: 25
-                                }
-                            ),
-                            Attr::new(
-                                "e",
-                                "f",
-                                Location {
-                                    line: 1,
-                                    column: 32
-                                }
-                            ),
-                        ],
-                        location: Location {
-                            line: 1,
-                            column: 39,
-                        },
-                    },
-                    FuncRetSyntax {
-                        type_: SyntaxRef::Atom {
-                            atom: AtomType::U32,
-                            location: Location {
-                                line: 1,
-                                column: 44,
-                            },
-                        },
-                        attrs: vec![],
-                        location: Location {
-                            line: 1,
-                            column: 44,
-                        },
-                    },
-                ],
-                attrs: Vec::new(),
                 location: Location { line: 1, column: 0 },
             }
         );

--- a/lucet-idl/src/types.rs
+++ b/lucet-idl/src/types.rs
@@ -33,23 +33,6 @@ pub struct Location {
     pub column: usize,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Attr {
-    pub key: String,
-    pub val: String,
-    pub location: Location,
-}
-
-impl Attr {
-    pub fn new(key: &str, val: &str, location: Location) -> Attr {
-        Attr {
-            key: key.to_owned(),
-            val: val.to_owned(),
-            location,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Ident(pub usize);
 
@@ -69,7 +52,6 @@ pub enum DataTypeRef {
 pub struct StructMember {
     pub type_: DataTypeRef,
     pub name: String,
-    pub attrs: Vec<Attr>,
     pub offset: usize,
 }
 
@@ -81,7 +63,6 @@ pub struct StructDataType {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EnumMember {
     pub name: String,
-    pub attrs: Vec<Attr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -104,7 +85,6 @@ pub enum DataTypeVariant {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataType {
     pub variant: DataTypeVariant,
-    pub attrs: Vec<Attr>,
     pub repr_size: usize,
     pub align: usize,
 }
@@ -113,7 +93,6 @@ pub struct DataType {
 pub struct FuncArg {
     pub type_: DataTypeRef,
     pub name: String,
-    pub attrs: Vec<Attr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -122,13 +101,11 @@ pub struct FuncDecl {
     pub binding_name: String,
     pub args: Vec<FuncArg>,
     pub rets: Vec<FuncRet>,
-    pub attrs: Vec<Attr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FuncRet {
     pub type_: DataTypeRef,
-    pub attrs: Vec<Attr>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! strcmp_tests {
     ( $TestRegion:path ) => {
-        use libc::{c_char, c_int, c_void, strcmp, uint64_t};
+        use libc::{c_char, c_int, c_void, strcmp};
         use lucet_runtime::vmctx::lucet_vmctx;
         use lucet_runtime::{lucet_hostcalls, Error, Limits, Region, Val, WASM_PAGE_SIZE};
         use std::ffi::CString;


### PR DESCRIPTION
The idea was we would use these to annotate datatypes with
backend-specific stuff, e.g. use this name for the struct in C and this name in Rust.
But we never ended up actually doing so. Defaults have worked fairly well so far.
When we end up needing annotations for specific nodes in the AST, we can go back
and add them just where they will be used.
