### PR TITLE
lucet-idl functions and binding expressions

### DIFF
--- a/lucet-idl/src/lexer.rs
+++ b/lucet-idl/src/lexer.rs
@@ -15,7 +15,8 @@ pub enum Token<'a> {
     Comma,    // ,
     Hash,     // #
     Equals,   // =
-    Arrow,    // ->
+    LArrow,   // <-
+    RArrow,   // ->
     Atom(AtomType),
     Word(&'a str),
     Quote(&'a str), // Found between balanced "". No escaping.
@@ -219,10 +220,20 @@ impl<'a> Lexer<'a> {
                         if self.looking_at("->") {
                             self.next_ch(); // Consume -
                             self.next_ch(); // Consume >
-                            token(Token::Arrow, loc)
+                            token(Token::RArrow, loc)
                         } else {
                             self.next_ch();
-                            error(LexError::InvalidChar('/'), loc)
+                            error(LexError::InvalidChar('-'), loc)
+                        }
+                    }
+                    '<' => {
+                        if self.looking_at("<-") {
+                            self.next_ch(); // Consume <
+                            self.next_ch(); // Consume -
+                            token(Token::LArrow, loc)
+                        } else {
+                            self.next_ch();
+                            error(LexError::InvalidChar('<'), loc)
                         }
                     }
                     '/' => {
@@ -349,6 +360,16 @@ mod tests {
         assert_eq!(lex.next(), token(Token::Colon, 1, 12));
         assert_eq!(lex.next(), token(Token::Comma, 1, 13));
         assert_eq!(lex.next(), token(Token::Semi, 1, 14));
+        assert_eq!(lex.next(), None);
+    }
+
+    #[test]
+    fn arrows() {
+        let mut lex = Lexer::new("<-->\n<- ->");
+        assert_eq!(lex.next(), token(Token::LArrow, 1, 0));
+        assert_eq!(lex.next(), token(Token::RArrow, 1, 2));
+        assert_eq!(lex.next(), token(Token::LArrow, 2, 0));
+        assert_eq!(lex.next(), token(Token::RArrow, 2, 3));
         assert_eq!(lex.next(), None);
     }
 }

--- a/lucet-idl/src/lib.rs
+++ b/lucet-idl/src/lib.rs
@@ -20,8 +20,8 @@ pub use crate::error::IDLError;
 pub use crate::module::Module;
 pub use crate::package::Package;
 pub use crate::types::{
-    AliasDataType, AtomType, DataType, DataTypeRef, DataTypeVariant, EnumDataType, FuncDecl,
-    FuncRet, Ident, Location, Name, Named, StructDataType, StructMember,
+    AliasDataType, AtomType, DataType, DataTypeRef, DataTypeVariant, EnumDataType, FuncDecl, Ident,
+    Location, Name, Named, StructDataType, StructMember,
 };
 
 use crate::c::CGenerator;

--- a/lucet-idl/src/rust.rs
+++ b/lucet-idl/src/rust.rs
@@ -5,10 +5,9 @@ use crate::error::IDLError;
 use crate::module::Module;
 use crate::package::Package;
 use crate::pretty_writer::PrettyWriter;
-use crate::types::AtomType;
 use crate::types::{
-    AliasDataType, DataType, DataTypeRef, DataTypeVariant, EnumDataType, FuncDecl, Ident, Named,
-    StructDataType,
+    AbiType, AliasDataType, AtomType, DataType, DataTypeRef, DataTypeVariant, EnumDataType,
+    FuncDecl, Ident, Named, StructDataType,
 };
 use heck::{CamelCase, SnakeCase};
 use std::collections::HashMap;
@@ -92,6 +91,16 @@ impl RustGenerator {
             U64 => "u64",
             I8 => "i8",
             I16 => "i16",
+            I32 => "i32",
+            I64 => "i64",
+            F32 => "f32",
+            F64 => "f64",
+        }
+    }
+
+    fn abitype_name(abi_type: &AbiType) -> &'static str {
+        use AbiType::*;
+        match abi_type {
             I32 => "i32",
             I64 => "i64",
             F32 => "f32",
@@ -208,16 +217,16 @@ impl RustGenerator {
             args += &format!(
                 "{}: {},",
                 a.name.to_snake_case(),
-                self.get_defined_typename(&a.type_)
+                Self::abitype_name(&a.type_)
             );
         }
 
         let func_rets = &func_decl_entry.entity.rets;
         let rets = if func_rets.len() == 0 {
-            "()".to_owned()
+            "()"
         } else {
             assert_eq!(func_rets.len(), 1);
-            self.get_defined_typename(&func_rets[0].type_).to_owned()
+            Self::abitype_name(&func_rets[0].type_)
         };
 
         self.w
@@ -238,16 +247,16 @@ impl RustGenerator {
             args += &format!(
                 "{}: {},",
                 a.name.to_snake_case(),
-                self.get_defined_typename(&a.type_)
+                Self::abitype_name(&a.type_)
             );
         }
 
         let func_rets = &func_decl_entry.entity.rets;
         let rets = if func_rets.len() == 0 {
-            "()".to_owned()
+            "()"
         } else {
             assert_eq!(func_rets.len(), 1);
-            self.get_defined_typename(&func_rets[0].type_).to_owned()
+            Self::abitype_name(&func_rets[0].type_)
         };
 
         self.w.writeln("#[no_mangle]")?.writeln(format!(

--- a/lucet-idl/src/types.rs
+++ b/lucet-idl/src/types.rs
@@ -146,6 +146,13 @@ pub struct FuncDecl {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BindDirection {
+    In,
+    Out,
+    InOut,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Name {
     pub name: String,
     pub location: Location,

--- a/lucet-idl/src/types.rs
+++ b/lucet-idl/src/types.rs
@@ -27,6 +27,48 @@ impl AtomType {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum AbiType {
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+impl AbiType {
+    pub fn repr_size(&self) -> usize {
+        match self {
+            AbiType::I32 | AbiType::F32 => 4,
+            AbiType::I64 | AbiType::F64 => 8,
+        }
+    }
+
+    pub fn from_atom<A: AsRef<AtomType>>(a: A) -> Self {
+        match a.as_ref() {
+            AtomType::Bool
+            | AtomType::U8
+            | AtomType::I8
+            | AtomType::U16
+            | AtomType::I16
+            | AtomType::U32
+            | AtomType::I32 => AbiType::I32,
+            AtomType::I64 | AtomType::U64 => AbiType::I64,
+            AtomType::F32 => AbiType::F32,
+            AtomType::F64 => AbiType::F64,
+        }
+    }
+
+    pub fn of_atom(a: AtomType) -> Option<Self> {
+        match a {
+            AtomType::I32 => Some(AbiType::I32),
+            AtomType::I64 => Some(AbiType::I64),
+            AtomType::F32 => Some(AbiType::F32),
+            AtomType::F64 => Some(AbiType::F64),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub struct Location {
     pub line: usize,
@@ -91,7 +133,7 @@ pub struct DataType {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FuncArg {
-    pub type_: DataTypeRef,
+    pub type_: AbiType,
     pub name: String,
 }
 
@@ -100,12 +142,7 @@ pub struct FuncDecl {
     pub field_name: String,
     pub binding_name: String,
     pub args: Vec<FuncArg>,
-    pub rets: Vec<FuncRet>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct FuncRet {
-    pub type_: DataTypeRef,
+    pub rets: Vec<FuncArg>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/lucet-idl/tests/example.idl
+++ b/lucet-idl/tests/example.idl
@@ -25,7 +25,7 @@ mod example {
 
     // functions
 
-    fn set_color(to: color) -> bool;
+    fn set_color(to: i32) -> r: i32;
 
-    fn get_structure(of: color) -> st;
+    fn get_structure(of: i32) -> s: i32;
 }


### PR DESCRIPTION
reworking lucet-idl function declarations to declare
1. the wasm ABI of a function
2. binding expressions that map the ABI to higher level structures