### PR TITLE
Reorganize lucet module binary format

### DIFF
--- a/lucet-analyze/src/main.rs
+++ b/lucet-analyze/src/main.rs
@@ -180,12 +180,17 @@ fn parse_trap_manifest<'a>(
     }
 }
 
-fn load_module<'b, 'a: 'b>(summary: &'a ArtifactSummary<'a>, native_data: &NativeData, tables: &'b [&[TableElement]]) -> Module<'b> {
+fn load_module<'b, 'a: 'b>(
+    summary: &'a ArtifactSummary<'a>,
+    native_data: &NativeData,
+    tables: &'b [&[TableElement]],
+) -> Module<'b> {
     let module_data_bytes = summary
         .read_memory(native_data.module_data_ptr, native_data.module_data_len)
         .unwrap();
 
-    let module_data = ModuleData::deserialize(module_data_bytes).expect("ModuleData can be deserialized");
+    let module_data =
+        ModuleData::deserialize(module_data_bytes).expect("ModuleData can be deserialized");
 
     let function_manifest_bytes = summary
         .read_memory(
@@ -474,7 +479,7 @@ fn print_summary(summary: ArtifactSummary<'_>) {
         let tables = unsafe {
             std::slice::from_raw_parts(
                 native_data.tables_ptr as *const &[TableElement],
-                native_data.tables_len as usize
+                native_data.tables_len as usize,
             )
         };
         let mut reconstructed_tables = Vec::new();
@@ -484,12 +489,15 @@ fn print_summary(summary: ArtifactSummary<'_>) {
 
         for table in tables {
             let table_bytes = summary
-                .read_memory(table.as_ptr() as usize as u64, (table.len() * mem::size_of::<TableElement>()) as u64)
+                .read_memory(
+                    table.as_ptr() as usize as u64,
+                    (table.len() * mem::size_of::<TableElement>()) as u64,
+                )
                 .unwrap();
             reconstructed_tables.push(unsafe {
                 std::slice::from_raw_parts(
                     table_bytes.as_ptr() as *const TableElement,
-                    table.len() as usize
+                    table.len() as usize,
                 )
             });
         }

--- a/lucet-analyze/src/main.rs
+++ b/lucet-analyze/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(bare_trait_objects)]
 
-use lucet_module_data::{Error, FunctionSpec, ModuleData, TrapManifest, TrapSite};
+use lucet_module_data::{
+    FunctionSpec, Module, ModuleData, NativeData, TableElement, TrapManifest, TrapSite,
+};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use colored::Colorize;
@@ -9,6 +11,7 @@ use std::env;
 use std::fs::File;
 use std::io::Cursor;
 use std::io::Read;
+use std::mem;
 
 #[derive(Debug)]
 struct ArtifactSummary<'a> {
@@ -16,20 +19,14 @@ struct ArtifactSummary<'a> {
     elf: &'a elf::Elf<'a>,
     symbols: StandardSymbols,
     data_segments: Option<DataSegments>,
-    module_data_bytes: Vec<u8>,
-    module_data: Option<Result<ModuleData<'a>, Error>>,
+    native_data: Option<NativeData>,
     exported_functions: Vec<&'a str>,
     imported_symbols: Vec<&'a str>,
 }
 
 #[derive(Debug)]
 struct StandardSymbols {
-    wasm_data_segments: Option<elf::sym::Sym>,
-    wasm_data_segments_len: Option<elf::sym::Sym>,
-    lucet_module_data: Option<elf::sym::Sym>,
-    lucet_module_data_len: Option<elf::sym::Sym>,
-    lucet_function_manifest: Option<elf::sym::Sym>,
-    lucet_function_manifest_len: Option<elf::sym::Sym>,
+    lucet_module: Option<elf::sym::Sym>,
 }
 
 #[derive(Debug)]
@@ -49,17 +46,9 @@ impl<'a> ArtifactSummary<'a> {
         Self {
             buffer: buffer,
             elf: elf,
-            symbols: StandardSymbols {
-                wasm_data_segments: None,
-                wasm_data_segments_len: None,
-                lucet_module_data: None,
-                lucet_module_data_len: None,
-                lucet_function_manifest: None,
-                lucet_function_manifest_len: None,
-            },
+            symbols: StandardSymbols { lucet_module: None },
             data_segments: None,
-            module_data_bytes: vec![],
-            module_data: None,
+            native_data: None,
             exported_functions: Vec::new(),
             imported_symbols: Vec::new(),
         }
@@ -91,16 +80,7 @@ impl<'a> ArtifactSummary<'a> {
                 .expect("strtab entry");
 
             match name {
-                "lucet_module_data" => self.symbols.lucet_module_data = Some(sym.clone()),
-                "lucet_module_data_len" => self.symbols.lucet_module_data_len = Some(sym.clone()),
-                "lucet_function_manifest" => {
-                    self.symbols.lucet_function_manifest = Some(sym.clone())
-                }
-                "lucet_function_manifest_len" => {
-                    self.symbols.lucet_function_manifest_len = Some(sym.clone())
-                }
-                "wasm_data_segments" => self.symbols.wasm_data_segments = Some(sym.clone()),
-                "wasm_data_segments_len" => self.symbols.wasm_data_segments_len = Some(sym.clone()),
+                "lucet_module" => self.symbols.lucet_module = Some(sym.clone()),
                 _ => {
                     if sym.st_bind() == elf::sym::STB_GLOBAL {
                         if sym.is_function() {
@@ -112,130 +92,22 @@ impl<'a> ArtifactSummary<'a> {
                 }
             }
         }
-    }
 
-    fn load_module_data(&self) -> Option<Result<ModuleData<'a>, Error>> {
-        if let (Some(ref data_sym), Some(ref data_len_sym)) = (
-            &self.symbols.lucet_module_data,
-            &self.symbols.lucet_module_data_len,
-        ) {
-            // TODO: validate that sym.st_size == 4
+        self.native_data = self.symbols.lucet_module.as_ref().map(|module_sym| {
             let buffer = self
-                .read_memory(data_len_sym.st_value, data_len_sym.st_size)
+                .read_memory(module_sym.st_value, mem::size_of::<NativeData>() as u64)
                 .unwrap();
             let mut rdr = Cursor::new(buffer);
-            let data_len = rdr.read_u32::<LittleEndian>().unwrap();
 
-            if data_len as u64 != data_sym.st_size {
-                print!("{}",
-                    format!(
-                        "Module data reported size ({} bytes) does not match size declared for symbol ({} bytes).",
-                        data_len,
-                        data_sym.st_size
-                    ).red().bold()
-                );
-                println!(" Assuming the symbol is correct, wish me luck!");
+            NativeData {
+                module_data_ptr: rdr.read_u64::<LittleEndian>().unwrap(),
+                module_data_len: rdr.read_u64::<LittleEndian>().unwrap(),
+                tables_ptr: rdr.read_u64::<LittleEndian>().unwrap(),
+                tables_len: rdr.read_u64::<LittleEndian>().unwrap(),
+                function_manifest_ptr: rdr.read_u64::<LittleEndian>().unwrap(),
+                function_manifest_len: rdr.read_u64::<LittleEndian>().unwrap(),
             }
-
-            let module_data_bytes = self
-                .read_memory(data_sym.st_value, data_sym.st_size)
-                .unwrap();
-            Some(ModuleData::deserialize(module_data_bytes))
-        } else {
-            None
-        }
-    }
-
-    fn load_function_manifest(&self) -> Option<&'a [FunctionSpec]> {
-        if let (Some(ref data_sym), Some(ref data_len_sym)) = (
-            &self.symbols.lucet_function_manifest,
-            &self.symbols.lucet_function_manifest_len,
-        ) {
-            // TODO: validate that sym.st_size == 4
-            let buffer = self
-                .read_memory(data_len_sym.st_value, data_len_sym.st_size)
-                .unwrap();
-            let mut rdr = Cursor::new(buffer);
-            let data_len = rdr.read_u32::<LittleEndian>().unwrap();
-
-            // cast up to u64 here to not overflow if data_len were an order of magnitude or so
-            // from u32::MAX
-            let expected_data_size = data_len as u64 * std::mem::size_of::<FunctionSpec>() as u64;
-            if expected_data_size != data_sym.st_size {
-                println!("{}",
-                    format!(
-                        "Function manifest expected size ({} bytes) does not match size declared for symbol ({} bytes).",
-                        expected_data_size,
-                        data_sym.st_size
-                    ).red().bold()
-                );
-                println!("  Assuming the symbol is correct, wish me luck!");
-            }
-
-            let module_data_bytes = self
-                .read_memory(data_sym.st_value, data_sym.st_size)
-                .unwrap();
-            Some(unsafe {
-                std::slice::from_raw_parts(
-                    module_data_bytes.as_ptr() as *const FunctionSpec,
-                    data_len as usize,
-                )
-            })
-        } else {
-            None
-        }
-    }
-
-    fn parse_data_segments(&self) -> Option<DataSegments> {
-        if let Some(ref data_sym) = self.symbols.wasm_data_segments {
-            if let Some(ref data_len_sym) = self.symbols.wasm_data_segments_len {
-                let mut data_segments = DataSegments {
-                    segments: Vec::new(),
-                };
-
-                // TODO: validate that sym.st_size == 4
-                let buffer = self
-                    .read_memory(data_len_sym.st_value, data_len_sym.st_size)
-                    .unwrap();
-                let mut rdr = Cursor::new(buffer);
-                let data_len = rdr.read_u32::<LittleEndian>().unwrap();
-                // TODO: validate that data_len == data_sym.st_size
-
-                let buffer = self
-                    .read_memory(data_sym.st_value, data_sym.st_size)
-                    .unwrap();
-                let mut rdr = Cursor::new(&buffer);
-
-                while rdr.position() < data_len as u64 {
-                    let _memory_index = rdr.read_u32::<LittleEndian>();
-                    // TODO: validate that memory_index == 0
-                    let offset = rdr.read_u32::<LittleEndian>().unwrap();
-                    let len = rdr.read_u32::<LittleEndian>().unwrap();
-
-                    let pos = rdr.position() as usize;
-                    let data_slice = &buffer[pos..pos + len as usize];
-
-                    let mut data = Vec::new();
-                    data.extend_from_slice(data_slice);
-
-                    let pad = (8 - (pos + len as usize) % 8) % 8;
-                    let new_pos = pos as u64 + len as u64 + pad as u64;
-                    rdr.set_position(new_pos);
-
-                    data_segments.segments.push(DataSegment {
-                        offset: offset,
-                        len: len,
-                        data: data,
-                    });
-                }
-
-                Some(data_segments)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
+        });
     }
 
     fn get_func_name_for_addr(&self, addr: u64) -> Option<&str> {
@@ -308,10 +180,37 @@ fn parse_trap_manifest<'a>(
     }
 }
 
-fn summarize_module_data<'a, 'b: 'a>(
-    summary: &'a ArtifactSummary<'a>,
-    module_data: ModuleData<'b>,
-) {
+fn load_module<'b, 'a: 'b>(summary: &'a ArtifactSummary<'a>, native_data: &NativeData, tables: &'b [&[TableElement]]) -> Module<'b> {
+    let module_data_bytes = summary
+        .read_memory(native_data.module_data_ptr, native_data.module_data_len)
+        .unwrap();
+
+    let module_data = ModuleData::deserialize(module_data_bytes).expect("ModuleData can be deserialized");
+
+    let function_manifest_bytes = summary
+        .read_memory(
+            native_data.function_manifest_ptr,
+            native_data.function_manifest_len,
+        )
+        .unwrap();
+    let function_manifest = unsafe {
+        std::slice::from_raw_parts(
+            function_manifest_bytes.as_ptr() as *const FunctionSpec,
+            native_data.function_manifest_len as usize,
+        )
+    };
+    Module {
+        module_data,
+        tables,
+        function_manifest,
+    }
+}
+
+fn summarize_module<'a, 'b: 'a>(summary: &'a ArtifactSummary<'a>, module: &Module<'b>) {
+    let module_data = &module.module_data;
+    let tables = module.tables;
+    let function_manifest = module.function_manifest;
+
     println!("  Heap Specification:");
     if let Some(heap_spec) = module_data.heap_spec() {
         println!("  {:9}: {} bytes", "Reserved", heap_spec.reserved_size);
@@ -323,7 +222,7 @@ fn summarize_module_data<'a, 'b: 'a>(
             println!("  {:9}: None", "Maximum");
         }
     } else {
-        println!("    {}", "MISSING".red().bold());
+        println!("  {}", "MISSING".red().bold());
     }
 
     println!("");
@@ -366,6 +265,16 @@ fn summarize_module_data<'a, 'b: 'a>(
     }
 
     println!("");
+    println!("Tables:");
+    if tables.len() == 0 {
+        println!("  No tables.");
+    } else {
+        for (i, table) in tables.iter().enumerate() {
+            println!("  Table {}: {:?}", i, table);
+        }
+    }
+
+    println!("");
     println!("Signatures:");
     for (i, s) in module_data.signatures().iter().enumerate() {
         println!("  Signature {}: {}", i, s);
@@ -373,88 +282,84 @@ fn summarize_module_data<'a, 'b: 'a>(
 
     println!("");
     println!("Functions:");
-    if let Some(function_manifest) = summary.load_function_manifest() {
-        if function_manifest.len() != module_data.function_info().len() {
+    if function_manifest.len() != module_data.function_info().len() {
+        println!(
+            "    {} function manifest and function info have diverging function counts",
+            "lucetc bug:".red().bold()
+        );
+        println!(
+            "      function_manifest length   : {}",
+            function_manifest.len()
+        );
+        println!(
+            "      module data function count : {}",
+            module_data.function_info().len()
+        );
+        println!("    Will attempt to display information about functions anyway, but trap/code information may be misaligned with symbols and signatures.");
+    }
+
+    for (i, f) in function_manifest.iter().enumerate() {
+        let header_name = summary.get_func_name_for_addr(f.ptr().as_usize() as u64);
+
+        if i >= module_data.function_info().len() {
+            // This is one form of the above-mentioned bug case
+            // Half the function information is missing, so just report the issue and continue.
             println!(
-                "    {} function manifest and function info have diverging function counts",
-                "lucetc bug:".red().bold()
+                "  Function {} {}",
+                i,
+                "is missing the module data part of its declaration".red()
             );
-            println!(
-                "      function_manifest length   : {}",
-                function_manifest.len()
-            );
-            println!(
-                "      module data function count : {}",
-                module_data.function_info().len()
-            );
-            println!("    Will attempt to display information about functions anyway, but trap/code information may be misaligned with symbols and signatures.");
-        }
-
-        for (i, f) in function_manifest.iter().enumerate() {
-            let header_name = summary.get_func_name_for_addr(f.ptr().as_usize() as u64);
-
-            if i >= module_data.function_info().len() {
-                // This is one form of the above-mentioned bug case
-                // Half the function information is missing, so just report the issue and continue.
-                println!(
-                    "  Function {} {}",
-                    i,
-                    "is missing the module data part of its declaration".red()
-                );
-                match header_name {
-                    Some(name) => {
-                        println!("    ELF header name: {}", name);
-                    }
-                    None => {
-                        println!("    No corresponding ELF symbol.");
-                    }
-                };
-                break;
-            }
-
-            let colorize_name = |x: Option<&str>| match x {
-                Some(name) => name.green(),
-                None => "None".red().bold(),
-            };
-
-            let fn_meta = &module_data.function_info()[i];
-            println!("  Function {} (name: {}):", i, colorize_name(fn_meta.name));
-            if fn_meta.name != header_name {
-                println!(
-                    "    Name {} with name declared in ELF headers: {}",
-                    "DISAGREES".red().bold(),
-                    colorize_name(header_name)
-                );
-            }
-
-            println!(
-                "    Signature (index {}): {}",
-                fn_meta.signature.as_u32() as usize,
-                module_data.signatures()[fn_meta.signature.as_u32() as usize]
-            );
-
-            println!("    Start: {:#010x}", f.ptr().as_usize());
-            println!("    Code length: {} bytes", f.code_len());
-            if let Some(trap_manifest) = parse_trap_manifest(&summary, f) {
-                let trap_count = trap_manifest.traps.len();
-
-                println!("    Trap information:");
-                if trap_count > 0 {
-                    println!(
-                        "      {} {} ...",
-                        trap_manifest.traps.len(),
-                        if trap_count == 1 { "trap" } else { "traps" },
-                    );
-                    for trap in trap_manifest.traps {
-                        println!("        $+{:#06x}: {:?}", trap.offset, trap.code);
-                    }
-                } else {
-                    println!("      No traps for this function");
+            match header_name {
+                Some(name) => {
+                    println!("    ELF header name: {}", name);
                 }
+                None => {
+                    println!("    No corresponding ELF symbol.");
+                }
+            };
+            break;
+        }
+
+        let colorize_name = |x: Option<&str>| match x {
+            Some(name) => name.green(),
+            None => "None".red().bold(),
+        };
+
+        let fn_meta = &module_data.function_info()[i];
+        println!("  Function {} (name: {}):", i, colorize_name(fn_meta.name));
+        if fn_meta.name != header_name {
+            println!(
+                "    Name {} with name declared in ELF headers: {}",
+                "DISAGREES".red().bold(),
+                colorize_name(header_name)
+            );
+        }
+
+        println!(
+            "    Signature (index {}): {}",
+            fn_meta.signature.as_u32() as usize,
+            module_data.signatures()[fn_meta.signature.as_u32() as usize]
+        );
+
+        println!("    Start: {:#010x}", f.ptr().as_usize());
+        println!("    Code length: {} bytes", f.code_len());
+        if let Some(trap_manifest) = parse_trap_manifest(&summary, f) {
+            let trap_count = trap_manifest.traps.len();
+
+            println!("    Trap information:");
+            if trap_count > 0 {
+                println!(
+                    "      {} {} ...",
+                    trap_manifest.traps.len(),
+                    if trap_count == 1 { "trap" } else { "traps" },
+                );
+                for trap in trap_manifest.traps {
+                    println!("        $+{:#06x}: {:?}", trap.offset, trap.code);
+                }
+            } else {
+                println!("      No traps for this function");
             }
         }
-    } else {
-        println!("  {}", "MISSING!".red().bold());
     }
 
     println!("");
@@ -536,52 +441,64 @@ fn print_summary(summary: ArtifactSummary<'_>) {
     println!("Required Symbols:");
     println!(
         "  {:30}: {}",
-        "lucet_module_data",
-        exists_to_str(&summary.symbols.lucet_module_data)
+        "lucet_module",
+        exists_to_str(&summary.symbols.lucet_module)
     );
-    println!(
-        "  {:30}: {}",
-        "lucet_module_data_len",
-        exists_to_str(&summary.symbols.lucet_module_data_len)
-    );
-    println!(
-        "  {:30}: {}",
-        "lucet_function_manifest",
-        exists_to_str(&summary.symbols.lucet_function_manifest)
-    );
-    println!(
-        "  {:30}: {}",
-        "lucet_function_manifest_len",
-        exists_to_str(&summary.symbols.lucet_function_manifest_len)
-    );
-    println!(
-        "  {:30}: {}",
-        "wasm_data_segments",
-        exists_to_str(&summary.symbols.wasm_data_segments)
-    );
-    println!(
-        "  {:30}: {}",
-        "wasm_data_segments_len",
-        exists_to_str(&summary.symbols.wasm_data_segments_len)
-    );
+    if let Some(ref native_data) = summary.native_data {
+        println!("Native module components:");
+        println!(
+            "  {:30}: {}",
+            "module_data_ptr",
+            ptr_to_str(native_data.module_data_ptr)
+        );
+        println!(
+            "  {:30}: {}",
+            "module_data_len", native_data.module_data_len
+        );
+        println!(
+            "  {:30}: {}",
+            "tables_ptr",
+            ptr_to_str(native_data.tables_ptr)
+        );
+        println!("  {:30}: {}", "tables_len", native_data.tables_len);
+        println!(
+            "  {:30}: {}",
+            "function_manifest_ptr",
+            ptr_to_str(native_data.function_manifest_ptr)
+        );
+        println!(
+            "  {:30}: {}",
+            "function_manifest_len", native_data.function_manifest_len
+        );
 
-    println!("\nModule data:");
-    match summary.load_module_data() {
-        Some(Ok(module_data)) => {
-            summarize_module_data(&summary, module_data);
+        let tables = unsafe {
+            std::slice::from_raw_parts(
+                native_data.tables_ptr as *const &[TableElement],
+                native_data.tables_len as usize
+            )
+        };
+        let mut reconstructed_tables = Vec::new();
+        // same situation as trap tables - these slices are valid as if the module was
+        // dlopen'd, but we jsut read it as a flat file. So read through the ELF view and use
+        // pointers to that for the real slices.
+
+        for table in tables {
+            let table_bytes = summary
+                .read_memory(table.as_ptr() as usize as u64, (table.len() * mem::size_of::<TableElement>()) as u64)
+                .unwrap();
+            reconstructed_tables.push(unsafe {
+                std::slice::from_raw_parts(
+                    table_bytes.as_ptr() as *const TableElement,
+                    table.len() as usize
+                )
+            });
         }
-        Some(Err(e)) => {
-            println!("  ERROR: {}", e.to_string().red().bold());
-        }
-        None => {
-            println!("  MISSING SYMBOL:");
-            if summary.symbols.lucet_module_data.is_none() {
-                println!("  - {}", "lucet_module_data".red().bold());
-            }
-            if summary.symbols.lucet_module_data_len.is_none() {
-                println!("  - {}", "lucet_module_data_len".red().bold());
-            }
-        }
+
+        let module = load_module(&summary, native_data, &reconstructed_tables);
+        println!("\nModule:");
+        summarize_module(&summary, &module);
+    } else {
+        println!("The symbol `lucet_module` is {}, so lucet-analyze cannot look at most of the interesting parts.", "MISSING".red().bold());
     }
 
     println!("");
@@ -596,6 +513,14 @@ fn print_summary(summary: ArtifactSummary<'_>) {
         }
     } else {
         println!("  {}", "MISSING!".red().bold());
+    }
+}
+
+fn ptr_to_str(p: u64) -> colored::ColoredString {
+    if p != 0 {
+        format!("exists; address: {:#x}", p).green()
+    } else {
+        "MISSING!".red().bold()
     }
 }
 

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -24,8 +24,8 @@ pub use crate::functions::{
 };
 pub use crate::globals::{Global, GlobalDef, GlobalSpec, GlobalValue};
 pub use crate::linear_memory::{HeapSpec, LinearMemorySpec, SparseData};
-pub use crate::module::Module;
-pub use crate::module_data::ModuleData;
+pub use crate::module::{Module, NativeData, LUCET_MODULE_SYM};
+pub use crate::module_data::{ModuleData, MODULE_DATA_SYM};
 pub use crate::signature::{ModuleSignature, PublicKey};
 pub use crate::tables::TableElement;
 pub use crate::traps::{TrapCode, TrapManifest, TrapSite};

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -10,8 +10,10 @@ mod error;
 mod functions;
 mod globals;
 mod linear_memory;
+mod module;
 mod module_data;
 mod signature;
+mod tables;
 mod traps;
 mod types;
 
@@ -22,8 +24,10 @@ pub use crate::functions::{
 };
 pub use crate::globals::{Global, GlobalDef, GlobalSpec, GlobalValue};
 pub use crate::linear_memory::{HeapSpec, LinearMemorySpec, SparseData};
+pub use crate::module::Module;
 pub use crate::module_data::ModuleData;
 pub use crate::signature::{ModuleSignature, PublicKey};
+pub use crate::tables::TableElement;
 pub use crate::traps::{TrapCode, TrapManifest, TrapSite};
 pub use crate::types::{Signature, ValueType};
 

--- a/lucet-module-data/src/lib.rs
+++ b/lucet-module-data/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::functions::{
 };
 pub use crate::globals::{Global, GlobalDef, GlobalSpec, GlobalValue};
 pub use crate::linear_memory::{HeapSpec, LinearMemorySpec, SparseData};
-pub use crate::module::{Module, NativeData, LUCET_MODULE_SYM};
+pub use crate::module::{Module, SerializedModule, LUCET_MODULE_SYM};
 pub use crate::module_data::{ModuleData, MODULE_DATA_SYM};
 pub use crate::signature::{ModuleSignature, PublicKey};
 pub use crate::tables::TableElement;

--- a/lucet-module-data/src/module.rs
+++ b/lucet-module-data/src/module.rs
@@ -1,6 +1,6 @@
+use crate::functions::FunctionSpec;
 use crate::module_data::ModuleData;
 use crate::tables::TableElement;
-use crate::functions::FunctionSpec;
 
 pub const LUCET_MODULE_SYM: &str = "lucet_module";
 

--- a/lucet-module-data/src/module.rs
+++ b/lucet-module-data/src/module.rs
@@ -4,6 +4,7 @@ use crate::tables::TableElement;
 
 pub const LUCET_MODULE_SYM: &str = "lucet_module";
 
+/// Module is the exposed structure that contains all the data backing a Lucet-compiled object.
 #[derive(Debug)]
 pub struct Module<'a> {
     pub module_data: ModuleData<'a>,
@@ -11,6 +12,10 @@ pub struct Module<'a> {
     pub function_manifest: &'a [FunctionSpec],
 }
 
+/// NativeData is a serialization-friendly form of Module, in that `ModuleData` is serialized, with
+/// the `module_data_*` fields here referring to that serialized data, while `tables_*` and
+/// `function_manifest_*` refer to the actual tables and function manifest data written in the
+/// binary.
 #[repr(C)]
 #[derive(Debug)]
 pub struct NativeData {

--- a/lucet-module-data/src/module.rs
+++ b/lucet-module-data/src/module.rs
@@ -1,0 +1,23 @@
+use crate::module_data::ModuleData;
+use crate::tables::TableElement;
+use crate::functions::FunctionSpec;
+
+pub const LUCET_MODULE_SYM: &str = "lucet_module";
+
+#[derive(Debug)]
+pub struct Module<'a> {
+    pub module_data: ModuleData<'a>,
+    pub tables: &'a [&'a [TableElement]],
+    pub function_manifest: &'a [FunctionSpec],
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct NativeData {
+    pub module_data_ptr: u64,
+    pub module_data_len: u64,
+    pub tables_ptr: u64,
+    pub tables_len: u64,
+    pub function_manifest_ptr: u64,
+    pub function_manifest_len: u64,
+}

--- a/lucet-module-data/src/module.rs
+++ b/lucet-module-data/src/module.rs
@@ -12,13 +12,12 @@ pub struct Module<'a> {
     pub function_manifest: &'a [FunctionSpec],
 }
 
-/// NativeData is a serialization-friendly form of Module, in that `ModuleData` is serialized, with
-/// the `module_data_*` fields here referring to that serialized data, while `tables_*` and
-/// `function_manifest_*` refer to the actual tables and function manifest data written in the
-/// binary.
+/// SerializedModule is a serialization-friendly form of Module, in that the `module_data_*` fields
+/// here refer to a serialized `ModuleData`, while `tables_*` and `function_manifest_*` refer to
+/// the actual tables and function manifest written in the binary.
 #[repr(C)]
 #[derive(Debug)]
-pub struct NativeData {
+pub struct SerializedModule {
     pub module_data_ptr: u64,
     pub module_data_len: u64,
     pub tables_ptr: u64,

--- a/lucet-module-data/src/module_data.rs
+++ b/lucet-module-data/src/module_data.rs
@@ -10,6 +10,8 @@ use crate::{
 use minisign::SignatureBones;
 use serde::{Deserialize, Serialize};
 
+pub const MODULE_DATA_SYM: &str = "lucet_module_data";
+
 /// The metadata (and some data) for a Lucet module.
 ///
 /// The lifetime parameter exists to support zero-copy deserialization for the `&str` and `&[u8]`

--- a/lucet-module-data/src/signature.rs
+++ b/lucet-module-data/src/signature.rs
@@ -85,7 +85,7 @@ impl RawModuleAndData {
                 format!("`{}` symbol not present", LUCET_MODULE_SYM),
             ))?;
 
-        // While `module_data` is the first field of the `NativeData` that `lucet_module` points
+        // While `module_data` is the first field of the `SerializedModule` that `lucet_module` points
         // to, it is a virtual address, not a file offset. The translation is somewhat tricky at
         // the moment, so just look at the corresponding `lucet_module_data` symbol for now.
         let module_data_symbol_data =

--- a/lucet-module-data/src/signature.rs
+++ b/lucet-module-data/src/signature.rs
@@ -62,6 +62,7 @@ impl ModuleSignature {
     }
 }
 
+#[allow(dead_code)]
 struct SymbolData {
     offset: usize,
     len: usize,

--- a/lucet-module-data/src/signature.rs
+++ b/lucet-module-data/src/signature.rs
@@ -1,4 +1,6 @@
 use crate::error::Error::{self, IOError, ModuleSignatureError};
+use crate::module::LUCET_MODULE_SYM;
+use crate::module_data::MODULE_DATA_SYM;
 use crate::ModuleData;
 use byteorder::{ByteOrder, LittleEndian};
 pub use minisign::{PublicKey, SecretKey};
@@ -76,25 +78,28 @@ impl RawModuleAndData {
         let mut obj_bin: Vec<u8> = Vec::new();
         File::open(&path)?.read_to_end(&mut obj_bin)?;
 
-        let module_data_symbol_data = Self::symbol_data(&obj_bin, "lucet_module_data", true)?
-            .ok_or(io::Error::new(
+        let native_data_symbol_data =
+            Self::symbol_data(&obj_bin, LUCET_MODULE_SYM, true)?.ok_or(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "module data not found",
+                format!("`{}` symbol not present", LUCET_MODULE_SYM),
             ))?;
-        let module_data_len_symbol_data =
-            Self::symbol_data(&obj_bin, "lucet_module_data_len", true)?.ok_or(io::Error::new(
+
+        // While `module_data` is the first field of the `NativeData` that `lucet_module` points
+        // to, it is a virtual address, not a file offset. The translation is somewhat tricky at
+        // the moment, so just look at the corresponding `lucet_module_data` symbol for now.
+        let module_data_symbol_data =
+            Self::symbol_data(&obj_bin, MODULE_DATA_SYM, true)?.ok_or(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "module length not found",
+                format!("`{}` symbol not present", MODULE_DATA_SYM),
             ))?;
-        assert_eq!(module_data_len_symbol_data.len, 4);
-        assert_eq!(
-            LittleEndian::read_u32(&obj_bin[module_data_len_symbol_data.offset..]) as usize,
-            module_data_symbol_data.len
-        );
+
+        let module_data_len =
+            LittleEndian::read_u64(&obj_bin[(native_data_symbol_data.offset + 8)..]) as usize;
+
         Ok(RawModuleAndData {
             obj_bin,
             module_data_offset: module_data_symbol_data.offset,
-            module_data_len: module_data_symbol_data.len,
+            module_data_len: module_data_len,
         })
     }
 

--- a/lucet-module-data/src/tables.rs
+++ b/lucet-module-data/src/tables.rs
@@ -1,6 +1,14 @@
+use crate::functions::FunctionPointer;
+
 #[repr(C)]
 #[derive(Clone, Debug)]
 pub struct TableElement {
     ty: u64,
-    pub rf: u64,
+    func: u64,
+}
+
+impl TableElement {
+    pub fn function_pointer(&self) -> FunctionPointer {
+        FunctionPointer::from_usize(self.func as usize)
+    }
 }

--- a/lucet-module-data/src/tables.rs
+++ b/lucet-module-data/src/tables.rs
@@ -1,0 +1,6 @@
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct TableElement {
+    ty: u64,
+    pub rf: u64,
+}

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -6,19 +6,12 @@ pub use crate::module::dl::DlModule;
 pub use crate::module::mock::{MockExportBuilder, MockModuleBuilder};
 pub use lucet_module_data::{
     FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, Global, GlobalSpec, GlobalValue,
-    HeapSpec, Signature, TrapCode, TrapManifest, ValueType,
+    HeapSpec, Signature, TableElement, TrapCode, TrapManifest, ValueType,
 };
 
 use crate::alloc::Limits;
 use crate::error::Error;
 use libc::c_void;
-
-#[repr(C)]
-#[derive(Clone, Debug)]
-pub struct TableElement {
-    ty: u64,
-    rf: u64,
-}
 
 /// Details about a program address.
 ///

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -3,8 +3,8 @@ use crate::module::{AddrDetails, GlobalSpec, HeapSpec, Module, ModuleInternal, T
 use libc::c_void;
 use libloading::Library;
 use lucet_module_data::{
-    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, Module as ModuleDataModule,
-    ModuleData, ModuleSignature, NativeData, PublicKey, Signature, LUCET_MODULE_SYM,
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, ModuleSignature,
+    NativeData, PublicKey, Signature, LUCET_MODULE_SYM,
 };
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
@@ -21,7 +21,7 @@ pub struct DlModule {
     fbase: *const c_void,
 
     /// Metadata decoded from inside the module
-    module: ModuleDataModule<'static>,
+    module: lucet_module_data::Module<'static>,
 }
 
 // for the one raw pointer only
@@ -111,7 +111,7 @@ impl DlModule {
         Ok(Arc::new(DlModule {
             lib,
             fbase,
-            module: ModuleDataModule {
+            module: lucet_module_data::Module {
                 module_data,
                 tables,
                 function_manifest,
@@ -170,9 +170,9 @@ impl ModuleInternal for DlModule {
             return Err(Error::FuncNotFound(table_id, func_id));
         }
         let table = self.table_elements()?;
-        let func: FunctionPointer = table
+        let func = table
             .get(func_id as usize)
-            .map(|element| FunctionPointer::from_usize(element.rf as usize))
+            .map(|element| element.function_pointer())
             .ok_or(Error::FuncNotFound(table_id, func_id))?;
 
         Ok(self.function_handle_from_ptr(func))

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -202,7 +202,6 @@ fn write_module_data<B: ClifBackend>(
     clif_module: &mut ClifModule<B>,
     decls: &ModuleDecls<'_>,
 ) -> Result<usize, LucetcError> {
-    use byteorder::{LittleEndian, WriteBytesExt};
     use cranelift_module::{DataContext, Linkage};
 
     let module_data_serialized: Vec<u8> = decls

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -137,7 +137,7 @@ impl<'a> Compiler<'a> {
 
         write_module_data(&mut self.clif_module, &self.decls)?;
         write_startfunc_data(&mut self.clif_module, &self.decls)?;
-        write_table_data(&mut self.clif_module, &self.decls)?;
+        let table_names = write_table_data(&mut self.clif_module, &self.decls)?;
 
         let function_manifest: Vec<(String, FunctionSpec)> = self
             .clif_module
@@ -155,7 +155,7 @@ impl<'a> Compiler<'a> {
             })
             .collect();
 
-        let obj = ObjectFile::new(self.clif_module.finish(), function_manifest)
+        let obj = ObjectFile::new(self.clif_module.finish(), function_manifest, table_names)
             .context(LucetcErrorKind::Output)?;
         Ok(obj)
     }

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -19,7 +19,7 @@ use cranelift_native;
 use cranelift_wasm::{translate_module, FuncTranslator, WasmError};
 use failure::{format_err, Fail, ResultExt};
 use lucet_module_data::bindings::Bindings;
-use lucet_module_data::{FunctionSpec, ModuleData};
+use lucet_module_data::{FunctionSpec, ModuleData, MODULE_DATA_SYM};
 
 #[derive(Debug, Clone, Copy)]
 pub enum OptLevel {
@@ -135,7 +135,7 @@ impl<'a> Compiler<'a> {
 
         stack_probe::declare_metadata(&mut self.decls, &mut self.clif_module).unwrap();
 
-        write_module_data(&mut self.clif_module, &self.decls)?;
+        let module_data_len = write_module_data(&mut self.clif_module, &self.decls)?;
         write_startfunc_data(&mut self.clif_module, &self.decls)?;
         let table_names = write_table_data(&mut self.clif_module, &self.decls)?;
 
@@ -155,8 +155,13 @@ impl<'a> Compiler<'a> {
             })
             .collect();
 
-        let obj = ObjectFile::new(self.clif_module.finish(), function_manifest, table_names)
-            .context(LucetcErrorKind::Output)?;
+        let obj = ObjectFile::new(
+            self.clif_module.finish(),
+            module_data_len,
+            function_manifest,
+            table_names,
+        )
+        .context(LucetcErrorKind::Output)?;
         Ok(obj)
     }
 
@@ -196,7 +201,7 @@ impl<'a> Compiler<'a> {
 fn write_module_data<B: ClifBackend>(
     clif_module: &mut ClifModule<B>,
     decls: &ModuleDecls<'_>,
-) -> Result<(), LucetcError> {
+) -> Result<usize, LucetcError> {
     use byteorder::{LittleEndian, WriteBytesExt};
     use cranelift_module::{DataContext, Linkage};
 
@@ -204,34 +209,20 @@ fn write_module_data<B: ClifBackend>(
         .get_module_data()?
         .serialize()
         .context(LucetcErrorKind::ModuleData)?;
-    {
-        let mut serialized_len: Vec<u8> = Vec::new();
-        serialized_len
-            .write_u32::<LittleEndian>(module_data_serialized.len() as u32)
-            .unwrap();
-        let mut data_len_ctx = DataContext::new();
-        data_len_ctx.define(serialized_len.into_boxed_slice());
 
-        let data_len_decl = clif_module
-            .declare_data("lucet_module_data_len", Linkage::Export, false, None)
-            .context(LucetcErrorKind::ModuleData)?;
-        clif_module
-            .define_data(data_len_decl, &data_len_ctx)
-            .context(LucetcErrorKind::ModuleData)?;
-    }
+    let module_data_len = module_data_serialized.len();
 
-    {
-        let mut module_data_ctx = DataContext::new();
-        module_data_ctx.define(module_data_serialized.into_boxed_slice());
+    let mut module_data_ctx = DataContext::new();
+    module_data_ctx.define(module_data_serialized.into_boxed_slice());
 
-        let module_data_decl = clif_module
-            .declare_data("lucet_module_data", Linkage::Export, true, None)
-            .context(LucetcErrorKind::ModuleData)?;
-        clif_module
-            .define_data(module_data_decl, &module_data_ctx)
-            .context(LucetcErrorKind::ModuleData)?;
-    }
-    Ok(())
+    let module_data_decl = clif_module
+        .declare_data(MODULE_DATA_SYM, Linkage::Local, true, None)
+        .context(LucetcErrorKind::ModuleData)?;
+    clif_module
+        .define_data(module_data_decl, &module_data_ctx)
+        .context(LucetcErrorKind::ModuleData)?;
+
+    Ok(module_data_len)
 }
 
 fn write_startfunc_data<B: ClifBackend>(

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -132,7 +132,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
             colocated: true,
         });
         let bound_ptr_gv = func.create_global_value(ir::GlobalValueData::Symbol {
-            name: table_decl.len_name.into(),
+            name: panic!("table_decl.len_name.into()"),
             offset: 0.into(),
             colocated: true,
         });

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -138,11 +138,10 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
             colocated: true,
         });
 
-        let table_bound_offset =
-            (TABLE_ENTRY_SIZE as u32)
-                .checked_mul(index.as_u32())
-                .and_then(|entry| entry.checked_add(NATIVE_POINTER_SIZE as u32))
-                .ok_or(WasmError::ImplLimitExceeded)?;
+        let table_bound_offset = (TABLE_ENTRY_SIZE as u32)
+            .checked_mul(index.as_u32())
+            .and_then(|entry| entry.checked_add(NATIVE_POINTER_SIZE as u32))
+            .ok_or(WasmError::ImplLimitExceeded)?;
 
         if table_bound_offset > std::i32::MAX as u32 {
             return Err(WasmError::ImplLimitExceeded);

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -1,7 +1,7 @@
 use super::runtime::RuntimeFunc;
 use crate::decls::ModuleDecls;
 use crate::pointer::{NATIVE_POINTER, NATIVE_POINTER_SIZE};
-use crate::table::TABLE_ENTRY_SIZE;
+use crate::table::TABLE_REF_SIZE;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, InstBuilder};
@@ -138,7 +138,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
             colocated: true,
         });
 
-        let table_bound_offset = (TABLE_ENTRY_SIZE as u32)
+        let table_bound_offset = (TABLE_REF_SIZE as u32)
             .checked_mul(index.as_u32())
             .and_then(|entry| entry.checked_add(NATIVE_POINTER_SIZE as u32))
             .ok_or(WasmError::ImplLimitExceeded)?;

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -1,6 +1,7 @@
 use super::runtime::RuntimeFunc;
 use crate::decls::ModuleDecls;
 use crate::pointer::{NATIVE_POINTER, NATIVE_POINTER_SIZE};
+use crate::table::{TABLE_ENTRY_SIZE, TABLE_SYM};
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, InstBuilder};
@@ -132,8 +133,10 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
             colocated: true,
         });
         let bound_ptr_gv = func.create_global_value(ir::GlobalValueData::Symbol {
-            name: panic!("table_decl.len_name.into()"),
-            offset: 0.into(),
+            name: self.module_decls.get_tables_list_name().as_externalname(),
+            offset: (((TABLE_ENTRY_SIZE * index.as_u32() as usize) + NATIVE_POINTER_SIZE) as u64
+                as i64)
+                .into(),
             colocated: true,
         });
         let bound_gv = func.create_global_value(ir::GlobalValueData::Load {

--- a/lucetc/src/function_manifest.rs
+++ b/lucetc/src/function_manifest.rs
@@ -1,71 +1,12 @@
+use crate::output::write_relocated_slice;
 use crate::traps::trap_sym_for_func;
-use byteorder::{LittleEndian, WriteBytesExt};
-use faerie::{Artifact, Decl, Link};
+use faerie::{Artifact, Decl};
 use failure::{Error, ResultExt};
 use lucet_module_data::FunctionSpec;
 use std::io::Cursor;
 use std::mem::size_of;
-use target_lexicon::BinaryFormat;
 
 pub const FUNCTION_MANIFEST_SYM: &str = "lucet_function_manifest";
-
-fn write_relocated_slice(
-    obj: &mut Artifact,
-    buf: &mut Cursor<Vec<u8>>,
-    from: &str,
-    to: Option<&str>,
-    len: u64,
-) -> Result<(), Error> {
-    match (to, len) {
-        (Some(to), 0) => {
-            // This is an imported slice of unknown size
-            let absolute_reloc = match obj.target.binary_format {
-                BinaryFormat::Elf => faerie::artifact::Reloc::Raw {
-                    reloc: goblin::elf::reloc::R_X86_64_64,
-                    addend: 0,
-                },
-                BinaryFormat::Macho => faerie::artifact::Reloc::Raw {
-                    reloc: goblin::mach::relocation::X86_64_RELOC_UNSIGNED as u32,
-                    addend: 0,
-                },
-                _ => panic!("Unsupported target format!"),
-            };
-
-            obj.link_with(
-                Link {
-                    from,
-                    to,
-                    at: buf.position(),
-                },
-                absolute_reloc,
-            )
-            .context(format!("linking {} into function manifest", to))?;
-        }
-        (Some(to), _len) => {
-            // This is a local buffer of known size
-            obj.link(Link {
-                from, // the data at `from` + `at` (eg. FUNCTION_MANIFEST_SYM)
-                to,   // is a reference to `to`    (eg. fn_name)
-                at: buf.position(),
-            })
-            .context(format!("linking {} into function manifest", to))?;
-        }
-        (None, len) => {
-            // There's actually no relocation to add, because there's no slice to put here.
-            //
-            // Since there's no slice, its length must be zero.
-            assert!(
-                len == 0,
-                "Invalid slice: no data, but there are more than zero bytes of it"
-            );
-        }
-    }
-
-    buf.write_u64::<LittleEndian>(0).unwrap();
-    buf.write_u64::<LittleEndian>(len).unwrap();
-
-    Ok(())
-}
 
 ///
 /// Writes a manifest of functions, with relocations, to the artifact.

--- a/lucetc/src/function_manifest.rs
+++ b/lucetc/src/function_manifest.rs
@@ -7,6 +7,8 @@ use std::io::Cursor;
 use std::mem::size_of;
 use target_lexicon::BinaryFormat;
 
+pub const FUNCTION_MANIFEST_SYM: &str = "lucet_function_manifest";
+
 fn write_relocated_slice(
     obj: &mut Artifact,
     buf: &mut Cursor<Vec<u8>>,
@@ -42,7 +44,7 @@ fn write_relocated_slice(
         (Some(to), _len) => {
             // This is a local buffer of known size
             obj.link(Link {
-                from, // the data at `from` + `at` (eg. manifest_sym)
+                from, // the data at `from` + `at` (eg. FUNCTION_MANIFEST_SYM)
                 to,   // is a reference to `to`    (eg. fn_name)
                 at: buf.position(),
             })
@@ -72,20 +74,8 @@ pub fn write_function_manifest(
     functions: &[(String, FunctionSpec)],
     obj: &mut Artifact,
 ) -> Result<(), Error> {
-    let manifest_len_sym = "lucet_function_manifest_len";
-    obj.declare(&manifest_len_sym, Decl::data().global())
-        .context(format!("declaring {}", &manifest_len_sym))?;
-
-    let manifest_sym = "lucet_function_manifest";
-    obj.declare(&manifest_sym, Decl::data().global())
-        .context(format!("declaring {}", &manifest_sym))?;
-
-    let mut manifest_len_buf: Vec<u8> = Vec::new();
-    manifest_len_buf
-        .write_u32::<LittleEndian>(functions.len() as u32)
-        .unwrap();
-    obj.define(manifest_len_sym, manifest_len_buf)
-        .context(format!("defining {}", &manifest_len_sym))?;
+    obj.declare(FUNCTION_MANIFEST_SYM, Decl::data())
+        .context(format!("declaring {}", FUNCTION_MANIFEST_SYM))?;
 
     let mut manifest_buf: Cursor<Vec<u8>> = Cursor::new(Vec::with_capacity(
         functions.len() * size_of::<FunctionSpec>(),
@@ -106,7 +96,7 @@ pub fn write_function_manifest(
         write_relocated_slice(
             obj,
             &mut manifest_buf,
-            &manifest_sym,
+            FUNCTION_MANIFEST_SYM,
             Some(fn_name),
             fn_spec.code_len() as u64,
         )?;
@@ -115,7 +105,7 @@ pub fn write_function_manifest(
         write_relocated_slice(
             obj,
             &mut manifest_buf,
-            &manifest_sym,
+            FUNCTION_MANIFEST_SYM,
             if fn_spec.traps_len() > 0 {
                 Some(&trap_sym)
             } else {
@@ -125,8 +115,8 @@ pub fn write_function_manifest(
         )?;
     }
 
-    obj.define(&manifest_sym, manifest_buf.into_inner())
-        .context(format!("defining {}", &manifest_sym))?;
+    obj.define(FUNCTION_MANIFEST_SYM, manifest_buf.into_inner())
+        .context(format!("defining {}", FUNCTION_MANIFEST_SYM))?;
 
     Ok(())
 }

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Cursor, Write};
 use std::path::Path;
+use target_lexicon::BinaryFormat;
 
 pub struct CraneliftFuncs {
     funcs: HashMap<Name, ir::Function>,
@@ -52,9 +53,10 @@ impl ObjectFile {
     ) -> Result<Self, Error> {
         stack_probe::declare_and_define(&mut product)?;
 
-        // stack_probe::declare_and_define never exists as clif, and as a result never exist as
-        // compiled code. This means the declared length of the stack probe's code is 0. This is
-        // incorrect, and must be fixed up before writing out the function manifest.
+        // stack_probe::declare_and_define never exists as clif, and as a result never exists a
+        // cranelift-compiled function. As a result, the declared length of the stack probe's
+        // "code" is 0. This is incorrect, and must be fixed up before writing out the function
+        // manifest.
 
         // because the stack probe is the last declared function...
         let last_idx = function_manifest.len() - 1;
@@ -104,45 +106,13 @@ impl ObjectFile {
         write_function_manifest(function_manifest.as_slice(), &mut product.artifact)?;
         link_tables(table_manifest.as_slice(), &mut product.artifact)?;
 
-        // And now we write out fields for the non-#[derive(Serialize)]-able parts of `Module`
-        let mut native_data = Cursor::new(Vec::with_capacity(NATIVE_POINTER_SIZE * 4));
-        product
-            .artifact
-            .declare(LUCET_MODULE_SYM, Decl::data().global())
-            .context(format!("declaring {}", LUCET_MODULE_SYM))?;
-
-        product.artifact.link(Link {
-            from: LUCET_MODULE_SYM,
-            to: MODULE_DATA_SYM,
-            at: native_data.position(),
-        })?;
-        native_data.write_u64::<LittleEndian>(0).unwrap();
-        native_data
-            .write_u64::<LittleEndian>(module_data_len as u64)
-            .unwrap();
-        product.artifact.link(Link {
-            from: LUCET_MODULE_SYM,
-            to: TABLE_SYM,
-            at: native_data.position(),
-        })?;
-        native_data.write_u64::<LittleEndian>(0).unwrap();
-        native_data
-            .write_u64::<LittleEndian>(table_manifest.len() as u64)
-            .unwrap();
-        product.artifact.link(Link {
-            from: LUCET_MODULE_SYM,
-            to: FUNCTION_MANIFEST_SYM,
-            at: native_data.position(),
-        })?;
-        native_data.write_u64::<LittleEndian>(0).unwrap();
-        native_data
-            .write_u64::<LittleEndian>(function_manifest.len() as u64)
-            .unwrap();
-
-        product
-            .artifact
-            .define(LUCET_MODULE_SYM, native_data.into_inner())
-            .context(format!("defining {}", LUCET_MODULE_SYM))?;
+        // And now write out the actual structure tying together all the data in this module.
+        write_module(
+            module_data_len,
+            table_manifest.len(),
+            function_manifest.len(),
+            &mut product.artifact,
+        )?;
 
         Ok(Self {
             artifact: product.artifact,
@@ -158,4 +128,100 @@ impl ObjectFile {
         self.artifact.write(file)?;
         Ok(())
     }
+}
+
+fn write_module(
+    module_data_len: usize,
+    table_manifest_len: usize,
+    function_manifest_len: usize,
+    obj: &mut Artifact,
+) -> Result<(), Error> {
+    let mut native_data = Cursor::new(Vec::with_capacity(NATIVE_POINTER_SIZE * 4));
+    obj.declare(LUCET_MODULE_SYM, Decl::data().global())
+        .context(format!("declaring {}", LUCET_MODULE_SYM))?;
+
+    write_relocated_slice(
+        obj,
+        &mut native_data,
+        LUCET_MODULE_SYM,
+        Some(MODULE_DATA_SYM),
+        module_data_len as u64,
+    )?;
+    write_relocated_slice(
+        obj,
+        &mut native_data,
+        LUCET_MODULE_SYM,
+        Some(TABLE_SYM),
+        table_manifest_len as u64,
+    )?;
+    write_relocated_slice(
+        obj,
+        &mut native_data,
+        LUCET_MODULE_SYM,
+        Some(FUNCTION_MANIFEST_SYM),
+        function_manifest_len as u64,
+    )?;
+
+    obj.define(LUCET_MODULE_SYM, native_data.into_inner())
+        .context(format!("defining {}", LUCET_MODULE_SYM))?;
+
+    Ok(())
+}
+
+pub(crate) fn write_relocated_slice(
+    obj: &mut Artifact,
+    buf: &mut Cursor<Vec<u8>>,
+    from: &str,
+    to: Option<&str>,
+    len: u64,
+) -> Result<(), Error> {
+    match (to, len) {
+        (Some(to), 0) => {
+            // This is an imported slice of unknown size
+            let absolute_reloc = match obj.target.binary_format {
+                BinaryFormat::Elf => faerie::artifact::Reloc::Raw {
+                    reloc: goblin::elf::reloc::R_X86_64_64,
+                    addend: 0,
+                },
+                BinaryFormat::Macho => faerie::artifact::Reloc::Raw {
+                    reloc: goblin::mach::relocation::X86_64_RELOC_UNSIGNED as u32,
+                    addend: 0,
+                },
+                _ => panic!("Unsupported target format!"),
+            };
+
+            obj.link_with(
+                Link {
+                    from,
+                    to,
+                    at: buf.position(),
+                },
+                absolute_reloc,
+            )
+            .context(format!("linking {} into function manifest", to))?;
+        }
+        (Some(to), _len) => {
+            // This is a local buffer of known size
+            obj.link(Link {
+                from, // the data at `from` + `at` (eg. FUNCTION_MANIFEST_SYM)
+                to,   // is a reference to `to`    (eg. fn_name)
+                at: buf.position(),
+            })
+            .context(format!("linking {} into function manifest", to))?;
+        }
+        (None, len) => {
+            // There's actually no relocation to add, because there's no slice to put here.
+            //
+            // Since there's no slice, its length must be zero.
+            assert!(
+                len == 0,
+                "Invalid slice: no data, but there are more than zero bytes of it"
+            );
+        }
+    }
+
+    buf.write_u64::<LittleEndian>(0).unwrap();
+    buf.write_u64::<LittleEndian>(len).unwrap();
+
+    Ok(())
 }

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -5,7 +5,7 @@ use crate::name::Name;
 use crate::pointer::NATIVE_POINTER_SIZE;
 use byteorder::{LittleEndian, WriteBytesExt};
 use cranelift_codegen::entity::EntityRef;
-use cranelift_module::{Backend as ClifBackend, DataContext, Linkage, Module as ClifModule};
+use cranelift_module::{Backend as ClifBackend, DataContext, Module as ClifModule};
 use cranelift_wasm::{TableElementType, TableIndex};
 use faerie::{Artifact, Link};
 use failure::{format_err, Error, ResultExt};

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -11,8 +11,12 @@ use faerie::{Artifact, Link};
 use failure::{format_err, Error, ResultExt};
 use std::io::Cursor;
 
+/// This symbol will be used to reference the `tables` field in `Module` - a sequence of tables.
+/// At the moment it will either be one or no tables, but in the future may grow.
 pub const TABLE_SYM: &str = "lucet_tables";
-pub const TABLE_ENTRY_SIZE: usize = NATIVE_POINTER_SIZE * 2;
+/// This is functionally the size of `&[TableEntry]`, but defined here because it may not
+/// necessarily have the same field ordering.
+pub const TABLE_REF_SIZE: usize = NATIVE_POINTER_SIZE * 2;
 
 #[derive(Debug, Clone)]
 enum Elem {
@@ -54,7 +58,7 @@ pub fn link_tables(tables: &[Name], obj: &mut Artifact) -> Result<(), Error> {
         obj.link(Link {
             from: TABLE_SYM,
             to: table.symbol(),
-            at: (TABLE_ENTRY_SIZE * idx) as u64,
+            at: (TABLE_REF_SIZE * idx) as u64,
         })
         .context(LucetcErrorKind::Table)?;
     }

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -12,8 +12,7 @@ use failure::{format_err, Error, ResultExt};
 use std::io::Cursor;
 
 pub const TABLE_SYM: &str = "lucet_tables";
-pub const TABLE_COUNT_SYM: &str = "lucet_tables_count";
-const TABLE_ENTRY_SIZE: usize = NATIVE_POINTER_SIZE * 2;
+pub const TABLE_ENTRY_SIZE: usize = NATIVE_POINTER_SIZE * 2;
 
 #[derive(Debug, Clone)]
 enum Elem {
@@ -68,10 +67,6 @@ pub fn write_table_data<B: ClifBackend>(
 ) -> Result<Vec<Name>, LucetcError> {
     let mut tables_vec = Cursor::new(Vec::new());
     let mut table_names: Vec<Name> = Vec::new();
-
-    let tables_data_decl = clif_module
-        .declare_data(TABLE_SYM, Linkage::Export, true, None)
-        .context(LucetcErrorKind::Table)?;
 
     if let Ok(table_decl) = decls.get_table(TableIndex::new(0)) {
         // Indirect calls are performed by looking up the callee function and type in a table that
@@ -147,23 +142,13 @@ pub fn write_table_data<B: ClifBackend>(
     table_data_ctx.define(inner.into_boxed_slice());
 
     clif_module
-        .define_data(tables_data_decl, &table_data_ctx)
-        .context(LucetcErrorKind::Table)?;
-
-    let mut tables_count_vec = Cursor::new(Vec::new());
-    tables_count_vec
-        .write_u64::<LittleEndian>(table_names.len() as u64)
-        .unwrap();
-
-    let mut table_count_data_ctx = DataContext::new();
-    table_count_data_ctx.define(tables_count_vec.into_inner().into_boxed_slice());
-
-    let tables_count_data_decl = clif_module
-        .declare_data(TABLE_COUNT_SYM, Linkage::Export, true, None)
-        .context(LucetcErrorKind::Table)?;
-
-    clif_module
-        .define_data(tables_count_data_decl, &table_count_data_ctx)
+        .define_data(
+            decls
+                .get_tables_list_name()
+                .as_dataid()
+                .expect("lucet_tables is declared as data"),
+            &table_data_ctx,
+        )
         .context(LucetcErrorKind::Table)?;
     Ok(table_names)
 }


### PR DESCRIPTION
This (finally!) makes a change we discussed a few months ago and has compilation produce binaries where all the internal components we need are reachable from a single symbol (`lucet_module`). This is nice for organization reasons, but generally reduces our dependence on `dlsym` as well as removing a few failure modes that were never realistically hit, like `function_manifest_len` not being present in a lucetc-compiled `.so`

Because other structures are internal and reachable via `lucet_module` and the `NativeData` it points to, most symbols are no longer exported.