### PR TITLE
wasmonkey: create a new name section if there isn't any

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +997,7 @@ dependencies = [
  "target-lexicon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmonkey 0.1.7",
+ "wasmonkey 0.1.8",
  "wasmparser 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1844,11 +1854,11 @@ dependencies = [
 
 [[package]]
 name = "wasmonkey"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2004,6 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum goblin 0.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6a4013e9182f2345c6b7829b9ef6e670bce0dfca12c6f974457ed2160c2c7fe9"
 "checksum goblin 0.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7f55d53401eb2fd30afd025c570b1946b6966344acf21b42e31286f3bf89e6a8"
+"checksum goblin 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "ac56b4753b6b8c2e052ca30717e5a09acf1b02a2c1681bf3d883bd660e5d22bd"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"

--- a/lucet-builtins/wasmonkey/Cargo.toml
+++ b/lucet-builtins/wasmonkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmonkey"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Lucet team <lucet@fastly.com>"]
 description = "Patch a WASM object file to replace a set of exported functions with imported functions from another library"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33"
 failure = "0.1"
-goblin = "0.0.22"
+goblin = "0.0.23"
 lazy_static = "1.3"
 parity-wasm = "0.38"
 serde = "1.0"

--- a/lucet-builtins/wasmonkey/src/patcher.rs
+++ b/lucet-builtins/wasmonkey/src/patcher.rs
@@ -6,7 +6,8 @@ use crate::sections::*;
 use crate::symbols::{self, ExtractedSymbols};
 use parity_wasm;
 use parity_wasm::elements::{
-    self, External, ImportEntry, ImportSection, Internal, Module, Section,
+    self, External, FunctionNameSubsection, ImportEntry, ImportSection, Internal, Module,
+    NameSection, Section,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -173,6 +174,12 @@ fn prepend_builtin_to_import_section(module: &mut Module, builtin: &Builtin) -> 
 
 fn prepend_builtin_to_names_section(module: &mut Module, builtin: &Builtin) -> Result<(), WError> {
     let import_name = builtin.import_name();
+    if module.names_section().is_none() {
+        let sections = module.sections_mut();
+        let function_names_subsection = FunctionNameSubsection::default();
+        let name_section = NameSection::new(None, Some(function_names_subsection), None);
+        sections.push(Section::Name(name_section));
+    }
     let names_section = module
         .names_section_mut()
         .expect("Names section not present");


### PR DESCRIPTION
We used to assume that there was always a name section.

But running `wasm-opt` can strip that section.