### PR TITLE
upgrade wasi-sdk to 6.0, which uses llvm 8.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN rustup target add wasm32-wasi
 
 RUN cargo install cargo-audit cargo-watch rsign2
 
-RUN curl -sS -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-5/wasi-sdk_5.0_amd64.deb \
-	&& dpkg -i wasi-sdk_5.0_amd64.deb && rm -f wasi-sdk_5.0_amd64.deb
+RUN curl -sS -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/wasi-sdk_6.0_amd64.deb \
+	&& dpkg -i wasi-sdk_6.0_amd64.deb && rm -f wasi-sdk_6.0_amd64.deb
 
 ENV WASI_SDK=/opt/wasi-sdk
 

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -10,5 +10,5 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/* && \
 	update-alternatives --install /usr/bin/wasm-ld wasm-ld /usr/bin/wasm-ld-8 100
 
-RUN curl -sL https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-5/libclang_rt.builtins-wasm32-wasi-5.0.tar.gz | tar x -zf - -C /usr/lib/llvm-8/lib/clang/8.0.0
+RUN curl -sL https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-6/libclang_rt.builtins-wasm32-wasi-6.0.tar.gz | tar x -zf - -C /usr/lib/llvm-8/lib/clang/8.0.0
 

--- a/devenv_build_toolchain_only.sh
+++ b/devenv_build_toolchain_only.sh
@@ -28,7 +28,7 @@ docker exec lucet tar c -pf - -C /opt lucet |
 
 docker exec lucet-toolchain mkdir /opt/wasi-sysroot
 
-docker exec lucet tar c -pf - -C /opt/wasi-sdk/share/sysroot . |
+docker exec lucet tar c -pf - -C /opt/wasi-sdk/share/wasi-sysroot . |
         docker exec -i lucet-toolchain tar x -pf - -C /opt/wasi-sysroot
 
 docker exec lucet-toolchain sh -c 'rm -f /opt/lucet/bin/wasm32-*'

--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -70,7 +70,7 @@ if ! install -d "$LUCET_PREFIX" 2>/dev/null; then
 fi
 
 # Find a WASI sysroot
-for wasi_sysroot in $WASI_SYSROOT ${WASI_SDK_PREFIX}/share/sysroot /opt/wasi-sysroot; do
+for wasi_sysroot in $WASI_SYSROOT ${WASI_SDK_PREFIX}/share/wasi-sysroot /opt/wasi-sysroot; do
     if [ -e "${wasi_sysroot}/include/wasi/core.h" ]; then
         WASI_SYSROOT="$wasi_sysroot"
     fi

--- a/lucet-wasi-sdk/src/lib.rs
+++ b/lucet-wasi-sdk/src/lib.rs
@@ -60,7 +60,7 @@ fn wasi_sysroot() -> PathBuf {
         Err(_) => {
             let mut path = wasi_sdk();
             path.push("share");
-            path.push("sysroot");
+            path.push("wasi-sysroot");
             path
         }
     }

--- a/lucet-wasi/build.rs
+++ b/lucet-wasi/build.rs
@@ -15,7 +15,7 @@ fn wasi_sysroot() -> PathBuf {
         Err(_) => {
             let mut path = wasi_sdk();
             path.push("share");
-            path.push("sysroot");
+            path.push("wasi-sysroot");
             path
         }
     }
@@ -28,7 +28,7 @@ fn wasm_clang_root() -> PathBuf {
             let mut path = wasi_sdk();
             path.push("lib");
             path.push("clang");
-            path.push("8.0.0");
+            path.push("8.0.1");
             path
         }
     }


### PR DESCRIPTION
tested with a local build of wasi-sdk 6.0. PR pending on https://github.com/CraneStation/wasi-sdk/pull/50 getting merged & tagged.