### PR TITLE
Do not try to count returns for unreachable calls as executed

### DIFF
--- a/lucet-runtime/tests/instruction_counting/unreachable_call.wat
+++ b/lucet-runtime/tests/instruction_counting/unreachable_call.wat
@@ -1,0 +1,17 @@
+(module
+  (func $main (export "test_function") (result i64)
+    ;; counting the const
+    i64.const 1
+    ;; return is counted by the caller, so we count 1 so far
+    return
+
+    ;; we had a bug where calls in unreachable code would still add
+    ;; one to the instruction counter to track a matching return,
+    ;; but the call would never be made, so the return would never
+    ;; occur, and the count was in error. 
+    call $main
+  )
+  (func $instruction_count (export "instruction_count") (result i64)
+    i64.const 1
+  )
+)

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -248,8 +248,12 @@ impl<'a> FuncInfo<'a> {
         // flushed and reset to 0.
         match op {
             Operator::CallIndirect { .. } | Operator::Call { .. } => {
-                // add 1 to count the return from the called function
-                self.scope_costs.last_mut().map(|x| *x = 1);
+                // only track the expected return if this call was reachable - if the call is not
+                // reachable, the "called" function won't return!
+                if reachable {
+                    // add 1 to count the return from the called function
+                    self.scope_costs.last_mut().map(|x| *x = 1);
+                }
             }
             Operator::Block { .. } | Operator::Loop { .. } | Operator::If { .. } => {
                 // opening a scope, which starts having executed zero wasm ops


### PR DESCRIPTION
`Call` and `CallIndirect` leave counting the corresponding `Return` to the caller, but we weren't checking if the caller was even reachable, so we would try to count even in unreachable calls.

This violated a [consistency check](https://github.com/fastly/lucet/blob/56396177cafe92ca945a0667bab0908672415e88/lucetc/src/function.rs#L236-L241) which caused failures in spec tests, and otherwise would have resulted in either incorrect overcounting or panicking in cranelift, so I'm pretty happy about having that assert now :)