### PR TITLE
Improve lucetc error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmonkey 0.1.8",
  "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1888,8 +1888,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wabt"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wabt-sys"
 version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wabt-sys"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2197,7 +2218,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
+"checksum wabt 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94b5f5d6984ca42df66280baa8a15ac188a173ddaf4580b574a98931c01920e7"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
+"checksum wabt-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b064c81821100adb4b71923cecfc67fef083db21c3bbd454b0162c7ffe63eeaa"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a026c1436af49d5537c7561c7474f81f7a754e36445fe52e6e88795a9747291c"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -37,7 +37,7 @@ goblin = "0.0.24"
 failure = "0.1"
 byteorder = "1.2"
 wasmonkey = { path = "../lucet-builtins/wasmonkey", version = "0.1.7" }
-wabt = "0.7"
+wabt = "0.9.1"
 tempfile = "3.0"
 bimap = "0.2"
 human-size = "0.4"

--- a/lucetc/src/load.rs
+++ b/lucetc/src/load.rs
@@ -4,7 +4,7 @@ use failure::*;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use wabt::{ErrorKind, wat2wasm};
+use wabt::{wat2wasm, ErrorKind};
 
 pub fn read_module<P: AsRef<Path>>(
     path: P,
@@ -47,8 +47,7 @@ pub fn read_bytes(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
                 },
                 _ => { }
             };
-            format_err!("{}", result)
-                .context(LucetcErrorKind::Input)
+            format_err!("{}", result).context(LucetcErrorKind::Input)
         })?
     };
     Ok(converted)

--- a/lucetc/src/main.rs
+++ b/lucetc/src/main.rs
@@ -19,7 +19,11 @@ fn main() {
     let opts = Options::get().unwrap();
 
     if let Err(err) = run(&opts) {
-        let mut msg = format!("{:?}", err);
+        let mut msg = format!("Error: {}.", err);
+        if let Some(cause) = err.as_fail().cause() {
+            msg.push(' ');
+            msg.push_str(&format!("{}", cause));
+        }
         if !msg.ends_with('\n') {
             msg.push('\n');
         }


### PR DESCRIPTION
Currently, given malformed wasm text like
```
(module
  (type (func (param i32 i32 i32 i32) (result i32)))
  (func $write (import "wasi_unstable" "fd_write") (type 0)) 
  (func $strlen (param i32) (result i32)
    (local i32 i32 i32)
    locaf l.get 0   ;; <----- this is the important line. "locaf" is very much not a wasm opcode!
    local.set 1
    local.get 1
    local.get 0
    i32.sub)
  (memory (;0;) 2)
  (export "memory" (memory 0)) 
  (data (i32.const 0) "0123456789\00a\00\00\00\00")
  (data (i32.const 16) "strlen(\"a\") is: \00\n")
  ;; iovec struct for eventually printing "strlen("a") is: ""
  (data (i32.const 64) "\10\00\00\00\12\00\00\00")
  (func $_start (export "_start")
    i32.const 32
    (call $strlen (i32.const 11))
    ;; fix up line to print by loading the digit at result of strlen (should be in [0,9])
    i32.load8_u
    i32.store8
    (call $write (i32.const 1) (i32.const 64) (i32.const 1) (i32.const 0)) 
    drop
  )
)
```
lucetc's error message is unhelpful:
```
ErrorMessage { msg: "Input is neither valid WASM nor WAT" }

Input
```

this adjusts lucetc to give nicer error messages and try to be more informative about the underlying cause:
```
Error: Input. invalid WAT input, parse error:
test.wast:6:5: error: unexpected token locaf, expected ).
    locaf l.get 0
    ^^^^^
test.wast:6:11: error: unexpected token l.get.
    locaf l.get 0
          ^^^^^
```

For comparison on non-wabt errors, the non-typo'd version of the above program would have
```
LucetcError { inner: ErrorMessage { msg: "Unknown module for symbol `wasi_unstable::fd_write`" }
                                                  
Translating module }
```
without a `bindings.json`. Now that error looks like
```
Error: Translating module. Unknown module for symbol `wasi_unstable::fd_write`
```

this is a draft because when I made `wabt-rs`'s `ErrorKind` public, I neglected to ensure the field in the reported error is accessible. So it's not. oops. Just to check the underlying error is what I wanted (it is!) I snuck in a transmute, but that will not stick around long