### PR TITLE
split lucet-idl and witx-frontend into two separate crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "witx-frontend"
+version = "0.1.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "xfailure"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 members = [
   "lucet-analyze",
   "lucet-idl",
+  "lucet-idl/witx-frontend",
   "lucet-idl/lucet-idl-test",
   "lucet-idl/lucet-idl-test/resources/rust_host",
   "lucet-module",

--- a/lucet-idl/src/config.rs
+++ b/lucet-idl/src/config.rs
@@ -2,12 +2,11 @@ use crate::error::IDLError;
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub witx: bool,
     pub backend: Backend,
 }
 
 impl Config {
-    pub fn parse(witx: bool, backend_opt: &str) -> Result<Self, IDLError> {
+    pub fn parse(backend_opt: &str) -> Result<Self, IDLError> {
         let backend = Backend::from_str(backend_opt).ok_or_else(|| {
             IDLError::UsageError(format!(
                 "Invalid backend: {}\nValid options are: {:?}",
@@ -15,7 +14,7 @@ impl Config {
                 Backend::options()
             ))
         })?;
-        Ok(Self { witx, backend })
+        Ok(Self { backend })
     }
 }
 

--- a/lucet-idl/src/error.rs
+++ b/lucet-idl/src/error.rs
@@ -1,5 +1,4 @@
 use crate::parser;
-use crate::witx::WitxError;
 use crate::Location;
 use std::io;
 
@@ -15,8 +14,6 @@ pub enum IDLError {
     ValidationError(#[cause] ValidationError),
     #[fail(display = "{}", _0)]
     Io(#[cause] io::Error),
-    #[fail(display = "{}", _0)]
-    Witx(#[cause] WitxError),
 }
 
 impl From<io::Error> for IDLError {
@@ -34,12 +31,6 @@ impl From<parser::ParseError> for IDLError {
 impl From<ValidationError> for IDLError {
     fn from(e: ValidationError) -> Self {
         IDLError::ValidationError(e)
-    }
-}
-
-impl From<WitxError> for IDLError {
-    fn from(e: WitxError) -> Self {
-        IDLError::Witx(e)
     }
 }
 

--- a/lucet-idl/src/lib.rs
+++ b/lucet-idl/src/lib.rs
@@ -15,7 +15,6 @@ pub mod pretty_writer;
 mod repr;
 mod rust;
 mod validate;
-mod witx;
 
 pub use crate::atoms::{AbiType, AtomType};
 pub use crate::config::{Backend, Config};
@@ -33,7 +32,6 @@ use crate::c::CGenerator;
 use crate::parser::Parser;
 use crate::rust::RustGenerator;
 use crate::validate::package_from_declarations;
-pub use crate::witx::load_witx;
 use lucet_module::bindings::Bindings;
 use std::collections::HashMap;
 use std::fs;
@@ -69,15 +67,9 @@ pub fn codegen(package: &Package, config: &Config, output: Box<dyn Write>) -> Re
 }
 
 pub fn run(config: &Config, input_path: &Path, output: Box<dyn Write>) -> Result<(), IDLError> {
-    if config.witx {
-        let doc = load_witx(input_path).map_err(IDLError::Witx)?;
-        println!("{:?}", doc);
-        Ok(())
-    } else {
-        let input = fs::read_to_string(input_path)?;
-        let pkg = parse_package(&input)?;
-        codegen(&pkg, config, output)
-    }
+    let input = fs::read_to_string(input_path)?;
+    let pkg = parse_package(&input)?;
+    codegen(&pkg, config, output)
 }
 
 impl Package {

--- a/lucet-idl/src/main.rs
+++ b/lucet-idl/src/main.rs
@@ -16,7 +16,7 @@ pub struct ExeConfig {
 impl ExeConfig {
     pub fn parse() -> Result<Self, IDLError> {
         let matches = App::new("lucet-idl")
-            .version("0.1.0")
+            .version(env!("CARGO_PKG_VERSION"))
             .about("lucet_idl code generator")
             .arg(
                 Arg::with_name("input")
@@ -39,13 +39,6 @@ impl ExeConfig {
                     .required(false)
                     .help("output path"),
             )
-            .arg(
-                Arg::with_name("witx")
-                    .long("witx")
-                    .takes_value(false)
-                    .required(false)
-                    .help("witx (interface-types, with extensions) mode"),
-            )
             .get_matches();
         let input_path = PathBuf::from(
             matches
@@ -53,10 +46,7 @@ impl ExeConfig {
                 .ok_or(IDLError::UsageError("Input file required".to_owned()))?,
         );
         let output_path = matches.value_of("output").map(PathBuf::from);
-        let config = Config::parse(
-            matches.is_present("witx"),
-            matches.value_of("backend").unwrap(),
-        )?;
+        let config = Config::parse(matches.value_of("backend").unwrap())?;
         Ok(ExeConfig {
             input_path,
             output_path,

--- a/lucet-idl/tests/example.rs
+++ b/lucet-idl/tests/example.rs
@@ -8,7 +8,6 @@ use tempfile::TempDir;
 fn compile_c_guest() {
     let config = lucet_idl::Config {
         backend: lucet_idl::Backend::CGuest,
-        witx: false,
     };
 
     let tempdir = TempDir::new().expect("create tempdir");
@@ -48,10 +47,7 @@ fn compile_and_test_rust_host() {
 */
 
 fn compile_and_test_rust(backend: lucet_idl::Backend) {
-    let config = lucet_idl::Config {
-        backend,
-        witx: false,
-    };
+    let config = lucet_idl::Config { backend };
 
     let tempdir = TempDir::new().expect("create tempdir");
 

--- a/lucet-idl/tests/wasi_unstable.rs
+++ b/lucet-idl/tests/wasi_unstable.rs
@@ -1,8 +1,0 @@
-use lucet_idl;
-use std::path::Path;
-
-#[test]
-fn validate_wasi_unstable() {
-    lucet_idl::load_witx(Path::new("tests/wasi_unstable.witx"))
-        .expect("parse and validate wasi_unstable.witx");
-}

--- a/lucet-idl/witx-frontend/Cargo.toml
+++ b/lucet-idl/witx-frontend/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "witx-frontend"
+version = "0.1.0"
+description = "Parse and validate witx file format"
+homepage = "https://github.com/fastly/lucet"
+repository = "https://github.com/fastly/lucet"
+license = "Apache-2.0 WITH LLVM-exception"
+categories = ["wasm"]
+authors = ["Pat Hickey <phickey@fastly.com>"]
+edition = "2018"
+
+[lib]
+crate-type=["rlib"]
+
+[[bin]]
+name = "witx-validate"
+path = "src/main.rs"
+
+[dependencies]
+clap = "2"
+failure = "0.1"

--- a/lucet-idl/witx-frontend/src/ast.rs
+++ b/lucet-idl/witx-frontend/src/ast.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
-pub use super::parser::BuiltinType;
+pub use crate::parser::BuiltinType;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Id(String);

--- a/lucet-idl/witx-frontend/src/lexer.rs
+++ b/lucet-idl/witx-frontend/src/lexer.rs
@@ -1,4 +1,5 @@
-use super::Location;
+use crate::Location;
+use failure::Fail;
 use std::path::{Path, PathBuf};
 use std::str::CharIndices;
 

--- a/lucet-idl/witx-frontend/src/lib.rs
+++ b/lucet-idl/witx-frontend/src/lib.rs
@@ -1,5 +1,5 @@
 /// Types describing a validated witx document
-pub mod ast;
+mod ast;
 /// Lexer text into tokens
 mod lexer;
 /// Witx syntax parsing from SExprs
@@ -11,12 +11,18 @@ mod toplevel;
 /// Validate declarations into ast
 mod validate;
 
-pub use ast::Document;
+pub use ast::{
+    AliasDatatype, BuiltinType, Datatype, DatatypeIdent, DatatypeVariant, Definition, Document,
+    Entry, EnumDatatype, FlagsDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam, Module,
+    ModuleDefinition, ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype, StructMember,
+    UnionDatatype, UnionVariant,
+};
+pub use lexer::LexError;
 pub use parser::{DeclSyntax, ParseError};
 pub use sexpr::SExprParseError;
-pub use toplevel::parse_witx;
-pub use validate::{validate_document, ValidationError};
+pub use validate::ValidationError;
 
+use failure::Fail;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -40,7 +46,9 @@ pub enum WitxError {
     Validation(#[cause] ValidationError),
 }
 
-pub fn load_witx<P: AsRef<Path>>(path: P) -> Result<Document, WitxError> {
+pub fn load<P: AsRef<Path>>(path: P) -> Result<Document, WitxError> {
+    use toplevel::parse_witx;
+    use validate::validate_document;
     let parsed_decls = parse_witx(path)?;
     validate_document(&parsed_decls).map_err(WitxError::Validation)
 }

--- a/lucet-idl/witx-frontend/src/main.rs
+++ b/lucet-idl/witx-frontend/src/main.rs
@@ -1,0 +1,38 @@
+use clap::{App, Arg};
+use std::path::Path;
+use std::process;
+use witx_frontend::load;
+
+pub fn main() {
+    let app = App::new("witx-validate")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Validate witx file format")
+        .arg(
+            Arg::with_name("input")
+                .required(true)
+                .help("path to root of witx document"),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .takes_value(false)
+                .required(false),
+        )
+        .get_matches();
+
+    match load(Path::new(app.value_of("input").expect("required arg"))) {
+        Ok(doc) => {
+            if app.is_present("verbose") {
+                println!("{:?}", doc)
+            }
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+            if app.is_present("verbose") {
+                eprintln!("{:?}", e);
+            }
+            process::exit(1);
+        }
+    }
+}

--- a/lucet-idl/witx-frontend/src/parser.rs
+++ b/lucet-idl/witx-frontend/src/parser.rs
@@ -1,5 +1,6 @@
-use super::sexpr::SExpr;
-use super::Location;
+use crate::sexpr::SExpr;
+use crate::Location;
+use failure::Fail;
 
 ///! Parser turns s-expressions into unvalidated syntax constructs.
 ///! conventions:

--- a/lucet-idl/witx-frontend/src/sexpr.rs
+++ b/lucet-idl/witx-frontend/src/sexpr.rs
@@ -1,6 +1,7 @@
-pub use super::lexer::LexError;
-use super::lexer::{Lexer, LocatedError, LocatedToken, Token};
-use super::Location;
+pub use crate::lexer::LexError;
+use crate::lexer::{Lexer, LocatedError, LocatedToken, Token};
+use crate::Location;
+use failure::Fail;
 use std::path::{Path, PathBuf};
 
 ///! The s-expression parser turns a string into a stream of SExprs.

--- a/lucet-idl/witx-frontend/src/toplevel.rs
+++ b/lucet-idl/witx-frontend/src/toplevel.rs
@@ -1,6 +1,6 @@
-use super::parser::{DeclSyntax, ParseError, TopLevelSyntax};
-use super::sexpr::SExprParser;
-use super::WitxError;
+use crate::parser::{DeclSyntax, ParseError, TopLevelSyntax};
+use crate::sexpr::SExprParser;
+use crate::WitxError;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/lucet-idl/witx-frontend/src/validate.rs
+++ b/lucet-idl/witx-frontend/src/validate.rs
@@ -1,14 +1,14 @@
-use super::ast::{
+use crate::{
+    parser::{
+        DatatypeIdentSyntax, DeclSyntax, EnumSyntax, FlagsSyntax, IdentSyntax, ImportTypeSyntax,
+        ModuleDeclSyntax, StructSyntax, TypedefSyntax, UnionSyntax,
+    },
     AliasDatatype, BuiltinType, Datatype, DatatypeIdent, DatatypeVariant, Definition, Document,
-    Entry, EnumDatatype, FlagsDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam, Module,
-    ModuleDefinition, ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype, StructMember,
-    UnionDatatype, UnionVariant,
+    Entry, EnumDatatype, FlagsDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam, Location,
+    Module, ModuleDefinition, ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype,
+    StructMember, UnionDatatype, UnionVariant,
 };
-use super::parser::{
-    DatatypeIdentSyntax, DeclSyntax, EnumSyntax, FlagsSyntax, IdentSyntax, ImportTypeSyntax,
-    ModuleDeclSyntax, StructSyntax, TypedefSyntax, UnionSyntax,
-};
-use super::Location;
+use failure::Fail;
 use std::collections::HashMap;
 use std::rc::Rc;
 


### PR DESCRIPTION
witx-frontend is going to get moved to the WASI repo. This separates it out from lucet-idl.

Once it is merged into the WASI repo, it will be deleted from this one.

At the moment, none of the generators in lucet-idl understand witx yet, so there's no need to even put a dependency on witx-frontend in that crate.

The test to parse wasi_unstable has been deleted, I'll have to recreate it with the right path in the wasi repo, and its otherwise trivial.