### PR TITLE
lucet-analyze: go through the ELF view to read the tables slice

### DIFF
--- a/lucet-analyze/src/main.rs
+++ b/lucet-analyze/src/main.rs
@@ -487,15 +487,21 @@ fn print_summary(summary: ArtifactSummary<'_>) {
             "function_manifest_len", serialized_module.function_manifest_len
         );
 
+        let tables_bytes = summary
+            .read_memory(
+                serialized_module.tables_ptr,
+                serialized_module.tables_len * mem::size_of::<&[TableElement]>() as u64,
+            )
+            .unwrap();
         let tables = unsafe {
             std::slice::from_raw_parts(
-                serialized_module.tables_ptr as *const &[TableElement],
+                tables_bytes.as_ptr() as *const &[TableElement],
                 serialized_module.tables_len as usize,
             )
         };
         let mut reconstructed_tables = Vec::new();
         // same situation as trap tables - these slices are valid as if the module was
-        // dlopen'd, but we jsut read it as a flat file. So read through the ELF view and use
+        // dlopen'd, but we just read it as a flat file. So read through the ELF view and use
         // pointers to that for the real slices.
 
         for table in tables {


### PR DESCRIPTION
we were going through the mapper to read each table, but incorrectly
assumed the pointer in the artifact to look at didn't need translation
too

This fixes the issue @shravanrn hit in #300 and while this gets `lucet-analyze` happily reading modules with tables, it doesn't do so very nicely:
```
Tables:
  Table 0: [TableElement { ty: 18446744073709551615, func: 0 }, TableElement { ty: 0, func: 1312 }, TableElement { ty: 0, func: 1328 }, TableElement { ty: 1, func: 1344 }]
```