### PR TITLE
upgrade to cranelift 0.44.0, wasmparser 0.39.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,18 +287,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-entity 0.43.1",
+ "cranelift-entity 0.44.0",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-bforest 0.43.1",
- "cranelift-codegen-meta 0.43.1",
- "cranelift-entity 0.43.1",
+ "cranelift-bforest 0.44.0",
+ "cranelift-codegen-meta 0.44.0",
+ "cranelift-codegen-shared 0.44.0",
+ "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,21 +309,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-entity 0.43.1",
+ "cranelift-codegen-shared 0.44.0",
+ "cranelift-entity 0.44.0",
 ]
 
 [[package]]
+name = "cranelift-codegen-shared"
+version = "0.44.0"
+
+[[package]]
 name = "cranelift-entity"
-version = "0.43.1"
+version = "0.44.0"
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-codegen 0.43.1",
- "cranelift-module 0.43.1",
+ "cranelift-codegen 0.44.0",
+ "cranelift-module 0.44.0",
  "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -331,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-codegen 0.43.1",
+ "cranelift-codegen 0.44.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,30 +347,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-codegen 0.43.1",
- "cranelift-entity 0.43.1",
+ "cranelift-codegen 0.44.0",
+ "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-codegen 0.43.1",
+ "cranelift-codegen 0.44.0",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
- "cranelift-codegen 0.43.1",
- "cranelift-entity 0.43.1",
- "cranelift-frontend 0.43.1",
+ "cranelift-codegen 0.44.0",
+ "cranelift-entity 0.44.0",
+ "cranelift-frontend 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +810,7 @@ name = "lucet-idl"
 version = "0.1.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.43.1",
+ "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.1.1",
@@ -850,7 +856,7 @@ version = "0.1.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.43.1",
+ "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,13 +999,13 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen 0.43.1",
- "cranelift-entity 0.43.1",
- "cranelift-faerie 0.43.1",
- "cranelift-frontend 0.43.1",
- "cranelift-module 0.43.1",
- "cranelift-native 0.43.1",
- "cranelift-wasm 0.43.1",
+ "cranelift-codegen 0.44.0",
+ "cranelift-entity 0.44.0",
+ "cranelift-faerie 0.44.0",
+ "cranelift-frontend 0.44.0",
+ "cranelift-module 0.44.0",
+ "cranelift-native 0.44.0",
+ "cranelift-wasm 0.44.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,41 +287,42 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-entity 0.41.0",
+ "cranelift-entity 0.43.1",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-bforest 0.41.0",
- "cranelift-codegen-meta 0.41.0",
- "cranelift-entity 0.41.0",
+ "cranelift-bforest 0.43.1",
+ "cranelift-codegen-meta 0.43.1",
+ "cranelift-entity 0.43.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-entity 0.41.0",
+ "cranelift-entity 0.43.1",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.41.0"
+version = "0.43.1"
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-codegen 0.41.0",
- "cranelift-module 0.41.0",
+ "cranelift-codegen 0.43.1",
+ "cranelift-module 0.43.1",
  "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -330,43 +331,44 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-codegen 0.41.0",
+ "cranelift-codegen 0.43.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-codegen 0.41.0",
- "cranelift-entity 0.41.0",
+ "cranelift-codegen 0.43.1",
+ "cranelift-entity 0.43.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-codegen 0.41.0",
+ "cranelift-codegen 0.43.1",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.41.0"
+version = "0.43.1"
 dependencies = [
- "cranelift-codegen 0.41.0",
- "cranelift-entity 0.41.0",
- "cranelift-frontend 0.41.0",
+ "cranelift-codegen 0.43.1",
+ "cranelift-entity 0.43.1",
+ "cranelift-frontend 0.43.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -802,7 +804,7 @@ name = "lucet-idl"
 version = "0.1.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.41.0",
+ "cranelift-entity 0.43.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.1.1",
@@ -848,7 +850,7 @@ version = "0.1.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.41.0",
+ "cranelift-entity 0.43.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,13 +993,13 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen 0.41.0",
- "cranelift-entity 0.41.0",
- "cranelift-faerie 0.41.0",
- "cranelift-frontend 0.41.0",
- "cranelift-module 0.41.0",
- "cranelift-native 0.41.0",
- "cranelift-wasm 0.41.0",
+ "cranelift-codegen 0.43.1",
+ "cranelift-entity 0.43.1",
+ "cranelift-faerie 0.43.1",
+ "cranelift-frontend 0.43.1",
+ "cranelift-module 0.43.1",
+ "cranelift-native 0.43.1",
+ "cranelift-wasm 0.43.1",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,7 +1014,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmonkey 0.1.8",
- "wasmparser 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1681,6 +1683,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "smallvec"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "string-interner"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.37.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2163,6 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum siphasher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9913c75df657d84a03fa689c016b0bb2863ff0b497b26a8d6e9703f8d5df03a8"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
@@ -2192,7 +2200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
-"checksum wasmparser 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7329e663dfa399d8ad1a31a9358fc777140cd741cea56d154abbc4c9f7edb137"
+"checksum wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a026c1436af49d5537c7561c7474f81f7a754e36445fe52e6e88795a9747291c"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/benchmarks/lucet-benchmarks/src/compile.rs
+++ b/benchmarks/lucet-benchmarks/src/compile.rs
@@ -19,7 +19,7 @@ fn compile_hello_all(c: &mut Criterion) {
                 criterion::BatchSize::SmallInput,
             )
         },
-        &[OptLevel::None, OptLevel::Standard, OptLevel::Fast],
+        &[OptLevel::None, OptLevel::Speed, OptLevel::SpeedAndSize],
     )
     .sample_size(10);
 

--- a/benchmarks/lucet-benchmarks/src/par.rs
+++ b/benchmarks/lucet-benchmarks/src/par.rs
@@ -42,7 +42,7 @@ fn par_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Fast);
+    compile_hello(&so_file, OptLevel::default());
 
     let module = DlModule::load(&so_file).unwrap();
 

--- a/benchmarks/lucet-benchmarks/src/par.rs
+++ b/benchmarks/lucet-benchmarks/src/par.rs
@@ -6,6 +6,9 @@ use rayon::prelude::*;
 use std::sync::Arc;
 use tempfile::TempDir;
 
+/// Common definiton of OptLevel
+const BENCHMARK_OPT_LEVEL: OptLevel = OptLevel::SpeedAndSize;
+
 /// Parallel instantiation.
 ///
 /// This measures how well the region handles concurrent instantiations from multiple
@@ -42,7 +45,7 @@ fn par_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::default());
+    compile_hello(&so_file, BENCHMARK_OPT_LEVEL);
 
     let module = DlModule::load(&so_file).unwrap();
 

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -30,7 +30,7 @@ fn hello_load_mkregion_and_instantiate<R: RegionCreate + 'static>(c: &mut Criter
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Fast);
+    compile_hello(&so_file, OptLevel::default());
 
     c.bench_function(
         &format!("hello_load_mkregion_and_instantiate ({})", R::TYPE_NAME),
@@ -58,7 +58,7 @@ fn hello_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Fast);
+    compile_hello(&so_file, OptLevel::default());
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -126,7 +126,7 @@ fn hello_drop_instance<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Fast);
+    compile_hello(&so_file, OptLevel::default());
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -247,7 +247,7 @@ fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::Fast);
+    compile_hello(&so_file, OptLevel::default());
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -7,6 +7,9 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 
+/// Common definiton of OptLevel
+const BENCHMARK_OPT_LEVEL: OptLevel = OptLevel::SpeedAndSize;
+
 const DENSE_HEAP_SIZES_KB: &'static [usize] =
     &[0, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2 * 1024, 4 * 1024];
 
@@ -30,7 +33,7 @@ fn hello_load_mkregion_and_instantiate<R: RegionCreate + 'static>(c: &mut Criter
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::default());
+    compile_hello(&so_file, BENCHMARK_OPT_LEVEL);
 
     c.bench_function(
         &format!("hello_load_mkregion_and_instantiate ({})", R::TYPE_NAME),
@@ -58,7 +61,7 @@ fn hello_instantiate<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::default());
+    compile_hello(&so_file, BENCHMARK_OPT_LEVEL);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -126,7 +129,7 @@ fn hello_drop_instance<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::default());
+    compile_hello(&so_file, BENCHMARK_OPT_LEVEL);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();
@@ -247,7 +250,7 @@ fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
     let workdir = TempDir::new().expect("create working directory");
 
     let so_file = workdir.path().join("out.so");
-    compile_hello(&so_file, OptLevel::default());
+    compile_hello(&so_file, BENCHMARK_OPT_LEVEL);
 
     let module = DlModule::load(&so_file).unwrap();
     let region = R::create(1, &Limits::default()).unwrap();

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.41.0" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.43.1" }
 failure = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.43.1" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.44.0" }
 failure = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -69,7 +69,7 @@ impl ScriptEnv {
         let bindings = bindings::spec_test_bindings();
         let compiler = Compiler::new(
             module,
-            OptLevel::Fast,
+            OptLevel::default(),
             &bindings,
             HeapSettings::default(),
             true,

--- a/lucet-wasi-sdk/tests/lucetc.rs
+++ b/lucet-wasi-sdk/tests/lucetc.rs
@@ -39,7 +39,7 @@ mod lucetc_tests {
         let m = module_from_c(&["empty"], &[]).expect("build module for empty");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile empty");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile empty");
         let mdata = c.module_data().unwrap();
         assert!(mdata.heap_spec().is_some());
         // clang creates 3 globals:
@@ -74,7 +74,7 @@ mod lucetc_tests {
         let m = module_from_c(&["c"], &["c"]).expect("build module for c");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile c");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile c");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.import_functions().len(), 0, "import functions");
         assert_eq!(mdata.export_functions().len(), 1, "export functions");
@@ -91,7 +91,7 @@ mod lucetc_tests {
         let m = module_from_c(&["d"], &["d"]).expect("build module for d");
         let b = d_only_test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile d");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile d");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.import_functions().len(), 1, "import functions");
         assert_eq!(mdata.export_functions().len(), 1, "export functions");
@@ -107,7 +107,7 @@ mod lucetc_tests {
         let m = module_from_c(&["c", "d"], &["c", "d"]).expect("build module for c & d");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile c & d");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile c & d");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.import_functions().len(), 0, "import functions");
         assert_eq!(mdata.export_functions().len(), 2, "export functions");

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -18,16 +18,16 @@ path = "src/main.rs"
 
 [dependencies]
 bincode = "1.1.4"
-cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.41.0" }
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.41.0" }
-cranelift-native = { path = "../cranelift/cranelift-native", version = "0.41.0" }
-cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.41.0" }
-cranelift-module = { path = "../cranelift/cranelift-module", version = "0.41.0" }
-cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.41.0" }
-cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.43.1" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.43.1" }
+cranelift-native = { path = "../cranelift/cranelift-native", version = "0.43.1" }
+cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.43.1" }
+cranelift-module = { path = "../cranelift/cranelift-module", version = "0.43.1" }
+cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.43.1" }
+cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.43.1" }
 target-lexicon = "0.8.0"
 lucet-module = { path = "../lucet-module", version = "0.1.1" }
-wasmparser = "0.37.0"
+wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -18,13 +18,13 @@ path = "src/main.rs"
 
 [dependencies]
 bincode = "1.1.4"
-cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.43.1" }
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.43.1" }
-cranelift-native = { path = "../cranelift/cranelift-native", version = "0.43.1" }
-cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.43.1" }
-cranelift-module = { path = "../cranelift/cranelift-module", version = "0.43.1" }
-cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.43.1" }
-cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.43.1" }
+cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.44.0" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.44.0" }
+cranelift-native = { path = "../cranelift/cranelift-native", version = "0.44.0" }
+cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.44.0" }
+cranelift-module = { path = "../cranelift/cranelift-module", version = "0.44.0" }
+cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.44.0" }
+cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.44.0" }
 target-lexicon = "0.8.0"
 lucet-module = { path = "../lucet-module", version = "0.1.1" }
 wasmparser = "0.39.1"

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -342,6 +342,11 @@ impl<'a> ModuleDecls<'a> {
                         .context(LucetcErrorKind::TranslatingModule)
                     }
                 }
+                GlobalInit::V128Const(_) => Err(format_err!(
+                    "invalid declaration of global {}: v128const type",
+                    ix.as_u32()
+                ))
+                .context(LucetcErrorKind::Unsupported),
             }?;
 
             globals.push(GlobalSpec::new(global, g_decl.export_names.clone()));

--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -100,10 +100,10 @@ impl Options {
         };
 
         let opt_level = match m.value_of("opt_level") {
-            None => OptLevel::default(),
+            None => OptLevel::SpeedAndSize,
             Some("0") => OptLevel::None,
-            Some("1") => OptLevel::Standard,
-            Some("2") | Some("fast") => OptLevel::Fast,
+            Some("1") => OptLevel::Speed,
+            Some("2") => OptLevel::SpeedAndSize,
             Some(_) => panic!("unknown value for opt-level"),
         };
 
@@ -214,8 +214,8 @@ impl Options {
                 Arg::with_name("opt_level")
                     .long("--opt-level")
                     .takes_value(true)
-                    .possible_values(&["0", "1", "2", "fast"])
-                    .help("optimization level (default: '1')"),
+                    .possible_values(&["0", "1", "2", "none", "speed", "speed_and_size"])
+                    .help("optimization level (default: 'speed_and_size'). 0 is alias to 'none', 1 to 'speed', 2 to 'speed_and_size'"),
             )
             .arg(
                 Arg::with_name("keygen")

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -42,7 +42,8 @@ mod module_data {
         let m = load_wat_module("exported_import");
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling exported_import");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false)
+            .expect("compiling exported_import");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -61,7 +62,8 @@ mod module_data {
         let m = load_wat_module("multiple_import");
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling multiple_import");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false)
+            .expect("compiling multiple_import");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -76,7 +78,8 @@ mod module_data {
         let m = load_wat_module("globals_export");
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling globals_export");
+        let c =
+            Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compiling globals_export");
         let mdata = c.module_data().unwrap();
 
         assert_eq!(mdata.globals_spec().len(), 1);
@@ -92,7 +95,7 @@ mod module_data {
         let m = load_wat_module("fibonacci");
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling fibonacci");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compiling fibonacci");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -106,7 +109,7 @@ mod module_data {
         let m = load_wat_module("arith");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling arith");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compiling arith");
         let mdata = c.module_data().unwrap();
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -123,7 +126,8 @@ mod module_data {
         ))
         .unwrap();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile duplicate_imports");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false)
+            .expect("compile duplicate_imports");
         let mdata = c.module_data().unwrap();
 
         assert_eq!(mdata.import_functions().len(), 2);
@@ -149,7 +153,7 @@ mod module_data {
         ))
         .unwrap();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile icall");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile icall");
         let mdata = c.module_data().unwrap();
 
         assert_eq!(mdata.import_functions().len(), 1);
@@ -185,7 +189,7 @@ mod module_data {
         let m = load_wat_module("icall");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile icall");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile icall");
         let _module_data = c.module_data().unwrap();
 
         /*  TODO can't express these with module data
@@ -210,7 +214,7 @@ mod module_data {
         let m = load_wat_module("icall_sparse");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile icall_sparse");
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile icall_sparse");
         let _module_data = c.module_data().unwrap();
 
         /*  TODO can't express these with module data
@@ -249,7 +253,8 @@ mod module_data {
         let b = Bindings::empty();
         let h = HeapSettings::default();
 
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile globals_import");
+        let c =
+            Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile globals_import");
         let module_data = c.module_data().unwrap();
         let gspec = module_data.globals_spec();
 
@@ -270,7 +275,7 @@ mod module_data {
         let m = load_wat_module("heap_spec_import");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h.clone(), false)
+        let c = Compiler::new(&m, OptLevel::default(), &b, h.clone(), false)
             .expect("compiling heap_spec_import");
 
         assert_eq!(
@@ -293,7 +298,7 @@ mod module_data {
         let m = load_wat_module("heap_spec_definition");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h.clone(), false)
+        let c = Compiler::new(&m, OptLevel::default(), &b, h.clone(), false)
             .expect("compiling heap_spec_definition");
 
         assert_eq!(
@@ -315,7 +320,8 @@ mod module_data {
         let m = load_wat_module("heap_spec_none");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compiling heap_spec_none");
+        let c =
+            Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compiling heap_spec_none");
         assert_eq!(c.module_data().unwrap().heap_spec(), None,);
     }
 
@@ -324,7 +330,7 @@ mod module_data {
         let m = load_wat_module("oversize_data_segment");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false);
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false);
         assert!(
             c.is_err(),
             "compilation error because data initializers are oversized"
@@ -347,7 +353,7 @@ mod module_data {
 
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let c = Compiler::new(&m, OptLevel::Fast, &b, h, false);
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false);
         assert!(
             c.is_err(),
             "compilation error because wasm module is invalid"
@@ -360,7 +366,8 @@ mod module_data {
         let m = load_wat_module("start_section");
         let b = Bindings::empty();
         let h = HeapSettings::default();
-        let _c = Compiler::new(&m, OptLevel::Fast, &b, h, false).expect("compile start_section");
+        let _c =
+            Compiler::new(&m, OptLevel::default(), &b, h, false).expect("compile start_section");
         /*
         assert!(
             p.module().start_section().is_some(),
@@ -378,8 +385,8 @@ mod compile {
         let m = load_wat_module(file);
         let b = super::test_bindings();
         let h = HeapSettings::default();
-        let c =
-            Compiler::new(&m, OptLevel::Fast, &b, h, false).expect(&format!("compile {}", file));
+        let c = Compiler::new(&m, OptLevel::default(), &b, h, false)
+            .expect(&format!("compile {}", file));
         let _obj = c.object_file().expect(&format!("codegen {}", file));
     }
     macro_rules! compile_test {


### PR DESCRIPTION
Brings in Cranelift 0.44.0 and wasmparser 0.39.1.

* Wasmparser 0.39.1 returns much better errors on a verifier error
* Cranelift-wasm uses the latest wasmparser, and exposes custom sections to module environment (relevant to #152)
* lots of other cranelift codegen updates. the known regression in 0.43 is fixed in this release