### PR TITLE
Move the stack guard page between the stack and heap

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -190,7 +190,7 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
                 // If the trap was a segv or bus fault and the addressed memory was outside the
                 // guard pages, it is also a fatal error
                 let outside_guard = (siginfo.si_signo == SIGSEGV || siginfo.si_signo == SIGBUS)
-                    && !inst.alloc.addr_in_heap_guard(siginfo.si_addr_ext());
+                    && !inst.alloc.addr_in_guard_page(siginfo.si_addr_ext());
 
                 // record the fault and jump back to the host context
                 inst.state = State::Faulted {

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -39,10 +39,10 @@ use std::sync::{Arc, Mutex, Weak};
 /// 0xXXXX: ~  .......heap.......   ~ // heap size is governed by limits.heap_address_space_size
 /// 0xXXXX: |                       |
 /// 0xN000: +-----------------------| <-- Stack (at heap_start + limits.heap_address_space_size)
+/// 0xNXXX: --- stack guard page ----
 /// 0xNXXX: |                       |
 /// 0xXXXX: ~  .......stack......   ~ // stack size is governed by limits.stack_size
 /// 0xXXXX: |                       |
-/// 0xXXXx: --- stack guard page ----
 /// 0xM000: +-----------------------| <-- Globals (at stack_start + limits.stack_size + PAGE_SIZE)
 /// 0xMXXX: |                       |
 /// 0xXXXX: ~  ......globals.....   ~
@@ -317,8 +317,8 @@ impl MmapRegion {
 
         // lay out the other sections in memory
         let heap = mem as usize + instance_heap_offset();
-        let stack = heap + region.limits.heap_address_space_size;
-        let globals = stack + region.limits.stack_size + host_page_size();
+        let stack = heap + region.limits.heap_address_space_size + host_page_size();
+        let globals = stack + region.limits.stack_size;
         let sigstack = globals + host_page_size();
 
         Ok(Slot {


### PR DESCRIPTION
where it was protecting against stack underflow into globals, which are
extremely unlikely. Far more likely, are stack overflows into the
instance's heap, where we accidentally caught those via heap guard space
instead. If an instance's `Limits` had the number of heap guard pages as
0, which is permissible, an instance with full utilization would then
map a page that had been acting as a stack guard page as read/write and
remove the guard-ness of that page.

This commit moves a page to be an outside-of-heap dedicated stack guard
page.