### PR TITLE
Switch uses of sigprocmask to pthread_sigmask

### DIFF
--- a/benchmarks/lucet-benchmarks/src/context.rs
+++ b/benchmarks/lucet-benchmarks/src/context.rs
@@ -347,14 +347,14 @@ fn context_init_swap_return_many_args(c: &mut Criterion) {
     });
 }
 
-/// Time the call to sigprocmask as used in `Context::init()`.
-fn context_sigprocmask(c: &mut Criterion) {
+/// Time the call to pthread_sigmask as used in `Context::init()`.
+fn context_pthread_sigmask(c: &mut Criterion) {
     use nix::sys::signal;
-    c.bench_function("context_sigprocmask", |b| {
+    c.bench_function("context_pthread_sigmask", |b| {
         b.iter_batched(
             || signal::SigSet::empty(),
             |mut sigset| {
-                signal::sigprocmask(signal::SigmaskHow::SIG_SETMASK, None, Some(&mut sigset))
+                signal::pthread_sigmask(signal::SigmaskHow::SIG_SETMASK, None, Some(&mut sigset))
                     .unwrap()
             },
             criterion::BatchSize::PerIteration,
@@ -367,5 +367,5 @@ pub fn context_benches(c: &mut Criterion) {
     context_swap_return(c);
     context_init_swap_return(c);
     context_init_swap_return_many_args(c);
-    context_sigprocmask(c);
+    context_pthread_sigmask(c);
 }

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -443,14 +443,14 @@ impl Context {
         // the parent and child contexts to `Context::swap` with.
         child.gpr.rbp = &mut stack[stack.len() - backstop_args] as *mut u64 as u64;
 
-        // Read the sigprocmask to be restored if we ever need to jump out of a signal handler. If
-        // this isn't possible, die.
-        signal::sigprocmask(
+        // Read the mask to be restored if we ever need to jump out of a signal handler. If this
+        // isn't possible, die.
+        signal::pthread_sigmask(
             signal::SigmaskHow::SIG_SETMASK,
             None,
             Some(&mut child.sigset),
         )
-        .expect("sigprocmask could not be retrieved");
+        .expect("pthread_sigmask could not be retrieved");
 
         Ok(())
     }
@@ -593,7 +593,7 @@ impl Context {
     /// `!` as a type like that is currently experimental.
     #[inline]
     pub unsafe fn set_from_signal(to: &Context) -> Result<(), nix::Error> {
-        signal::sigprocmask(signal::SigmaskHow::SIG_SETMASK, Some(&to.sigset), None)?;
+        signal::pthread_sigmask(signal::SigmaskHow::SIG_SETMASK, Some(&to.sigset), None)?;
         Context::set(to)
     }
 


### PR DESCRIPTION
`pthread_sigmask` is the safe choice for a multithreaded environment. Per `sigprocmask(2)`:

> The use of sigprocmask() is unspecified in a multithreaded process; see pthread_sigmask(3).