### PR TITLE
Package lucetc using Docker

### DIFF
--- a/Dockerfile.lucetc
+++ b/Dockerfile.lucetc
@@ -1,0 +1,34 @@
+
+FROM ubuntu:16.04 AS builder
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	build-essential \
+	curl \
+	cmake \
+	ninja-build \
+	ca-certificates \
+	software-properties-common \
+	libssl-dev \
+	pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain nightly-2019-09-25 -y && \
+        /root/.cargo/bin/rustup update nightly
+ENV PATH=/root/.cargo/bin:$PATH
+
+COPY . /lucet
+WORKDIR /lucet
+RUN cargo build --release -p lucetc
+
+FROM ubuntu:16.04
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	binutils \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /lucet/target/release/lucetc /usr/local/bin/lucetc
+RUN mkdir /usr/local/share/lucetc
+COPY --from=builder /lucet/lucet-wasi/bindings.json /usr/local/share/lucetc/lucet-wasi.bindings.json
+
+CMD /usr/local/bin/lucetc --help

--- a/lucet-analyze/Cargo.toml
+++ b/lucet-analyze/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-goblin="0.0.21"
+goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.6.1"
 lucet-module = { path = "../lucet-module", version = "0.1.1" }

--- a/lucet-builtins/wasmonkey/Cargo.toml
+++ b/lucet-builtins/wasmonkey/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33"
 failure = "0.1"
-goblin = "0.0.23"
+goblin = "0.0.24"
 lazy_static = "1.3"
 parity-wasm = "0.38"
 serde = "1.0"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -32,7 +32,7 @@ clap="2.32"
 log = "0.4"
 env_logger = "0.6"
 faerie = "0.11.0"
-goblin = "0.0.22"
+goblin = "0.0.24"
 failure = "0.1"
 byteorder = "1.2"
 wasmonkey = { path = "../lucet-builtins/wasmonkey", version = "0.1.7" }


### PR DESCRIPTION
The control plane group needed an example, so here is one that works straight from the repo.

Note: this is not tested as part of CI, because if we add anything else to Travis CI itll implode into a black hole of tech debt and take us all down with it.

You can test it by hand with something like:

```
docker build . -t lucetc -f Dockerfile.lucetc
docker run -it -v "$(pwd)":/devenv lucetc lucetc "/devenv/lucet-wasi/examples/build/hello.wasm" --bindings /usr/local/share/lucetc/lucet-wasi.bindings.json
```