### PR TITLE
Ignore non-c/wat files in lucet-validate test rather than failing

### DIFF
--- a/lucet-validate/tests/wasitests.rs
+++ b/lucet-validate/tests/wasitests.rs
@@ -50,7 +50,10 @@ mod lucet_wasi_tests {
             {
                 Some("c") => c_to_wasm(&entry_path),
                 Some("wat") => wat_to_wasm(&entry_path),
-                _ => panic!("unsupported extension: {:?}", entry_path),
+                _ => {
+                    eprintln!("unsupported extension: {:?}", entry_path);
+                    continue;
+                }
             };
             validator
                 .validate(&entry_wasm)


### PR DESCRIPTION
Ephemeral files left around by editors were causing a panic.