### PR TITLE
lucetc 0.2.0: fix --opt-level {none, speed, speed_and_size}

### DIFF
--- a/lucetc/src/options.rs
+++ b/lucetc/src/options.rs
@@ -110,9 +110,9 @@ impl Options {
 
         let opt_level = match m.value_of("opt_level") {
             None => OptLevel::SpeedAndSize,
-            Some("0") => OptLevel::None,
-            Some("1") => OptLevel::Speed,
-            Some("2") => OptLevel::SpeedAndSize,
+            Some("0") | Some("none") => OptLevel::None,
+            Some("1") | Some("speed") => OptLevel::Speed,
+            Some("2") | Some("speed_and_size") => OptLevel::SpeedAndSize,
             Some(_) => panic!("unknown value for opt-level"),
         };
 


### PR DESCRIPTION
`lucetc` usage indicates `none`, `speed` and `speed_and_size` as optimization levels, but these are rejected.

```sh
$ lucetc --opt-level none a.c
thread 'main' panicked at 'unknown value for opt-level', lucetc/src/options.rs:116:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

This fixes it.