### PR TITLE
More permissive module version check

### DIFF
--- a/lucet-module/src/version_info.rs
+++ b/lucet-module/src/version_info.rs
@@ -45,8 +45,8 @@ impl VersionInfo {
         }
     }
 
-    /// A more permissive version check than for version equality. This check will allow a more
-    /// precise `other`
+    /// A more permissive version check than for version equality. This check will allow an `other`
+    /// version that is more specific than `self`, but matches for data that is available.
     pub fn compatible_with(&self, other: &VersionInfo) -> bool {
         if !(self.valid() || other.valid()) {
             return false;

--- a/lucet-module/src/version_info.rs
+++ b/lucet-module/src/version_info.rs
@@ -41,7 +41,11 @@ impl fmt::Display for VersionInfo {
 impl VersionInfo {
     pub fn new(major: u16, minor: u16, patch: u16, version_hash: [u8; 8]) -> VersionInfo {
         VersionInfo {
-            major, minor, patch, reserved: 0x8000, version_hash
+            major,
+            minor,
+            patch,
+            reserved: 0x8000,
+            version_hash,
         }
     }
 

--- a/lucet-module/tests/version.rs
+++ b/lucet-module/tests/version.rs
@@ -2,19 +2,9 @@ use lucet_module::VersionInfo;
 
 #[test]
 fn version_equality() {
-    let precise = VersionInfo::new(
-         0,
-         1,
-         2,
-         [0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61]
-    );
+    let precise = VersionInfo::new(0, 1, 2, [0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61]);
 
-    let imprecise = VersionInfo::new(
-         0,
-         1,
-         2,
-         [0, 0, 0, 0, 0, 0, 0, 0]
-    );
+    let imprecise = VersionInfo::new(0, 1, 2, [0, 0, 0, 0, 0, 0, 0, 0]);
 
     // first, these are two different versions.
     assert_ne!(precise, imprecise);

--- a/lucet-module/tests/version.rs
+++ b/lucet-module/tests/version.rs
@@ -1,0 +1,28 @@
+use lucet_module::VersionInfo;
+
+#[test]
+fn version_equality() {
+    let precise = VersionInfo::new(
+         0,
+         1,
+         2,
+         [0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61]
+    );
+
+    let imprecise = VersionInfo::new(
+         0,
+         1,
+         2,
+         [0, 0, 0, 0, 0, 0, 0, 0]
+    );
+
+    // first, these are two different versions.
+    assert_ne!(precise, imprecise);
+
+    // something running a version only as detailed as `major.minor.patch` can run a matching
+    // version that may include a commit hash
+    assert!(imprecise.compatible_with(&precise));
+
+    // something running a version `major.minor.patch-commit` rejects a version less specific
+    assert!(!precise.compatible_with(&imprecise));
+}

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -61,17 +61,17 @@ impl DlModule {
         let serialized_module: &SerializedModule =
             unsafe { serialized_module_ptr.as_ref().unwrap() };
 
-        let version = serialized_module.version.clone();
+        let module_version = serialized_module.version.clone();
 
         let runtime_version =
             VersionInfo::current(include_str!(concat!(env!("OUT_DIR"), "/commit_hash")).as_bytes());
 
-        if !version.valid() {
+        if !module_version.valid() {
             return Err(lucet_incorrect_module!("reserved bit is not set. This module is likely too old for this lucet-runtime to load."));
-        } else if version != runtime_version {
+        } else if !runtime_version.compatible_with(&module_version) {
             return Err(lucet_incorrect_module!(
                 "version mismatch. module has version {}, while this runtime is version {}",
-                version,
+                module_version,
                 runtime_version,
             ));
         }
@@ -130,7 +130,7 @@ impl DlModule {
             lib,
             fbase,
             module: lucet_module::Module {
-                version,
+                version: module_version,
                 module_data,
                 tables,
                 function_manifest,


### PR DESCRIPTION
Motivated by https://github.com/fastly/ExecuteD/pull/9#issuecomment-541101657, when the runtime doesn't have a commit hash in its version info, but the lucetc does, we were rejecting modules simply for having a too specific version.