### PR TITLE
Bump lucet crates to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,15 +760,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-benchmarks"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime 0.2.0",
- "lucet-runtime-internals 0.2.0",
- "lucet-wasi 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime 0.2.1",
+ "lucet-runtime-internals 0.2.1",
+ "lucet-wasi 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -783,8 +783,8 @@ dependencies = [
  "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucetc 0.2.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -800,10 +800,10 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.0",
- "lucet-wasi 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-runtime 0.2.1",
+ "lucet-wasi 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -816,13 +816,13 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.0",
- "lucet-wasi 0.2.0",
+ "lucet-runtime 0.2.1",
+ "lucet-wasi 0.2.1",
 ]
 
 [[package]]
 name = "lucet-module"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -839,28 +839,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
+ "lucet-module 0.2.1",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime-internals 0.2.0",
- "lucet-runtime-tests 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime-internals 0.2.1",
+ "lucet-runtime-tests 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,7 +881,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
+ "lucet-module 0.2.1",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,27 +891,27 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime-internals 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime-internals 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime 0.2.1",
+ "lucetc 0.2.1",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -920,12 +920,12 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-wasi-sdk 0.2.0",
+ "lucet-wasi-sdk 0.2.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -942,11 +942,11 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime 0.2.0",
- "lucet-runtime-internals 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime 0.2.1",
+ "lucet-runtime-internals 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -954,16 +954,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-runtime 0.2.0",
- "lucet-wasi 0.2.0",
- "lucet-wasi-sdk 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-runtime 0.2.1",
+ "lucet-wasi 0.2.1",
+ "lucet-wasi-sdk 0.2.1",
+ "lucetc 0.2.1",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-validate 0.2.0",
- "lucetc 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-validate 0.2.1",
+ "lucetc 0.2.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucetc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1007,8 +1007,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.0",
- "lucet-validate 0.2.0",
+ "lucet-module 0.2.1",
+ "lucet-validate 0.2.1",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Lucet version 0.2.0
+# Lucet version 0.2.1
 
 [workspace]
 members = [

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-benchmarks"
-version = "0.2.0"
+version = "0.2.1"
 description = "Benchmarks for the Lucet runtime"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.2.0"
+version = "0.2.1"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.2.0"
+version = "0.2.1"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.6.1"
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 libc = "=0.2.59"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.2.0" }
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
 num-traits = "0.2"
 num-derive = "0.2"
 
@@ -20,9 +20,9 @@ num-derive = "0.2"
 byteorder = "1.2"
 failure = "0.1"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "0.2.0" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.2.0" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.0" }
+lucetc = { path = "../lucetc", version = "0.2.1" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.2.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
 nix = "0.13"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "0.2.0" }
+lucet-module = { path = "../../lucet-module", version = "0.2.1" }
 
 bitflags = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 failure = "0.1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "0.2.0" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.2.0" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.2.0" }
-lucetc = { path = "../../lucetc", version = "0.2.0" }
+lucet-module = { path = "../../lucet-module", version = "0.2.1" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.2.1" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.2.1" }
+lucetc = { path = "../../lucetc", version = "0.2.1" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.2.0"
+version = "0.2.1"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,9 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "0.2.0" }
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
-lucet-runtime = { path = "../lucet-runtime", version = "0.2.0" }
+lucetc = { path = "../lucetc", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.2.1" }
 wabt = "0.7"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.2.0"
+version = "0.2.1"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.44.0" 
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
 tempfile = "3.0"
 wabt = "0.7"
 

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.2.0"
+version = "0.2.1"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "0.2.0" }
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
+lucetc = { path = "../lucetc", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
 tempfile = "3.0"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "0.2.0" }
+lucet-validate = { path = "../lucet-validate", version  = "0.2.1" }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -29,15 +29,15 @@ clap = "2.23"
 failure = "0.1"
 human-size = "0.4"
 libc = "=0.2.59"
-lucet-runtime = { path = "../lucet-runtime", version = "0.2.0" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.2.0" }
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.2.1" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
 nix = "0.13"
 rand = "0.6"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.0" }
-lucetc = { path = "../lucetc", version = "0.2.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
+lucetc = { path = "../lucetc", version = "0.2.1" }
 tempfile = "3.0"
 
 [build-dependencies.bindgen]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -26,8 +26,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.44.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.44.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.44.0" }
 target-lexicon = "0.8.0"
-lucet-module = { path = "../lucet-module", version = "0.2.0" }
-lucet-validate = { path = "../lucet-validate", version = "0.2.0" }
+lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucet-validate = { path = "../lucet-validate", version = "0.2.1" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"


### PR DESCRIPTION
This is the last of the packaging stuff for now, and some point later we can look at fixing cyclic dev-dependencies. This would include #333 and #328 in 0.2.0 -> 0.2.1, which seems appropriate for a patch bump.