### PR TITLE
Add very basic JSON formatting for lucetc errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,8 @@ dependencies = [
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -44,6 +44,8 @@ human-size = "0.4"
 parity-wasm = "0.38"
 minisign = "0.5.11"
 memoffset = "0.5.1"
+serde = "1.0"
+serde_json = "1.0"
 
 [package.metadata.deb]
 name = "fst-lucetc"


### PR DESCRIPTION
This is meant to be a starting point for more semantic error reporting, but in order to get there we'll need to do a broader refactor of our error types.

Example use and output:
```
acfoltzer@stribog:~/src/isolation/public/lucetc % cargo run -p lucetc -- sdflkj
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `/home/acfoltzer/src/isolation/public/target/debug/lucetc sdflkj`
Error: No such file or directory (os error 2)

acfoltzer@stribog:~/src/isolation/public/lucetc % cargo run -p lucetc -- sdflkj --error-style json
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `/home/acfoltzer/src/isolation/public/target/debug/lucetc sdflkj --error-style json`
{"error":"No such file or directory (os error 2)"}
```

In `--error-style json` mode, the error is a single object with a string field `"error"` that contains the printed representation of the underlying error. It's printed on a single line to stderr.

A followup to this will add `Serialize` instances to the error types themselves, rather than just printing the errors at the front-end. This will require some heavier-duty refactoring of the error types which has been something we've needed to do for a while.