### PR TITLE
Allow KillState's `exit_guest_region` to be name-mangled

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -73,11 +73,8 @@ _lucet_context_backstop:
 
     // load instance pointer, arg 1
     mov 16(%rbp), %rdi
-#ifdef __ELF__
-    call instance_kill_state_exit_guest_region@PLT
-#else
-    call instance_kill_state_exit_guest_region
-#endif
+    // call `lucet_runtime_internals::instance::execution::exit_guest_region`
+    call *24(%rbp)
 
     mov (%rbp), %rdi  /* parent context to arg 1 */
     mov 8(%rbp), %rsi  /* own context to arg 2 */

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -407,7 +407,12 @@ impl Context {
         // set up an initial call stack for guests to bootstrap into and execute
         let mut stack_builder = CallStackBuilder::new(stack);
 
-        // store a pointer to the context swap completion flag, to signal the guest has activated
+        // pass this crate's `exit_guest_region` function pointer, so we can allow
+        // `exit_guest_function` to be name mangled. Mangling is beneficial as it allows multiple
+        // crates to depend on `lucet-runtime-internals` without linker conflicts.
+        stack_builder.push(crate::instance::execution::exit_guest_region as u64);
+
+        // store a pointer to kill state, which the guest interacts with to safely exit
         stack_builder.push(kill_state as u64);
 
         // store arguments we'll pass to `lucet_context_swap` on the stack, above where the guest

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -125,8 +125,7 @@ pub struct KillState {
     tid_change_notifier: Condvar,
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn instance_kill_state_exit_guest_region(kill_state: *mut KillState) {
+pub unsafe extern "C" fn exit_guest_region(kill_state: *mut KillState) {
     let terminable = (*kill_state).terminable.swap(false, Ordering::SeqCst);
     if !terminable {
         // Something else has taken the terminable flag, so it's not safe to actually exit a


### PR DESCRIPTION
By being `#[no_mangle]` this causes unnecessary symbol conflicts in the presence of other `lucet-runtime-internals`es.