### PR TITLE
Bump versions to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,15 +760,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-benchmarks"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime 0.2.2",
- "lucet-runtime-internals 0.2.2",
- "lucet-wasi 0.2.1",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime 0.3.0",
+ "lucet-runtime-internals 0.3.0",
+ "lucet-wasi 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -783,8 +783,8 @@ dependencies = [
  "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucetc 0.3.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -800,10 +800,10 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.2",
- "lucet-wasi 0.2.1",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-runtime 0.3.0",
+ "lucet-wasi 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -816,13 +816,13 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.2",
- "lucet-wasi 0.2.1",
+ "lucet-runtime 0.3.0",
+ "lucet-wasi 0.3.0",
 ]
 
 [[package]]
 name = "lucet-module"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -839,28 +839,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
+ "lucet-module 0.3.0",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime-internals 0.2.2",
- "lucet-runtime-tests 0.2.2",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime-internals 0.3.0",
+ "lucet-runtime-tests 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,7 +881,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
+ "lucet-module 0.3.0",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,50 +891,50 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime-internals 0.2.2",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime-internals 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime 0.2.2",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime 0.3.0",
+ "lucetc 0.3.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-validate"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.44.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-wasi-sdk 0.2.1",
+ "lucet-wasi-sdk 0.3.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "witx 0.3.0",
 ]
 
 [[package]]
 name = "lucet-wasi"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -942,11 +942,11 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime 0.2.2",
- "lucet-runtime-internals 0.2.2",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime 0.3.0",
+ "lucet-runtime-internals 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -954,16 +954,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-runtime 0.2.2",
- "lucet-wasi 0.2.1",
- "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-runtime 0.3.0",
+ "lucet-wasi 0.3.0",
+ "lucet-wasi-sdk 0.3.0",
+ "lucetc 0.3.0",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -977,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-validate 0.2.1",
- "lucetc 0.2.2",
+ "lucet-module 0.3.0",
+ "lucet-validate 0.3.0",
+ "lucetc 0.3.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucetc"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1007,8 +1007,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.2.1",
- "lucet-validate 0.2.1",
+ "lucet-module 0.3.0",
+ "lucet-validate 0.3.0",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1880,17 +1880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wabt"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wabt"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1898,16 +1887,6 @@ dependencies = [
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wabt-sys"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2219,9 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
-"checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
 "checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,11 +764,11 @@ version = "0.2.1"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime 0.2.1",
- "lucet-runtime-internals 0.2.1",
+ "lucet-runtime 0.2.2",
+ "lucet-runtime-internals 0.2.2",
  "lucet-wasi 0.2.1",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -784,7 +784,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -800,10 +800,10 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.1",
+ "lucet-runtime 0.2.2",
  "lucet-wasi 0.2.1",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -816,7 +816,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-idl 0.2.0",
- "lucet-runtime 0.2.1",
+ "lucet-runtime 0.2.2",
  "lucet-wasi 0.2.1",
 ]
 
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -857,10 +857,10 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime-internals 0.2.1",
- "lucet-runtime-tests 0.2.1",
+ "lucet-runtime-internals 0.2.2",
+ "lucet-runtime-tests 0.2.2",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,15 +891,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime-internals 0.2.1",
+ "lucet-runtime-internals 0.2.2",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -910,8 +910,8 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime 0.2.1",
- "lucetc 0.2.1",
+ "lucet-runtime 0.2.2",
+ "lucetc 0.2.2",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -943,10 +943,10 @@ dependencies = [
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime 0.2.1",
- "lucet-runtime-internals 0.2.1",
+ "lucet-runtime 0.2.2",
+ "lucet-runtime-internals 0.2.2",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -960,10 +960,10 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
- "lucet-runtime 0.2.1",
+ "lucet-runtime 0.2.2",
  "lucet-wasi 0.2.1",
  "lucet-wasi-sdk 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -982,13 +982,13 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.2.1",
  "lucet-validate 0.2.1",
- "lucetc 0.2.1",
+ "lucetc 0.2.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucetc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,7 +1016,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmonkey 0.1.8",
  "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1891,13 +1891,13 @@ dependencies = [
 
 [[package]]
 name = "wabt"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "wabt-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "wabt-sys"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2220,9 +2220,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
-"checksum wabt 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94b5f5d6984ca42df66280baa8a15ac188a173ddaf4580b574a98931c01920e7"
+"checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
-"checksum wabt-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b064c81821100adb4b71923cecfc67fef083db21c3bbd454b0162c7ffe63eeaa"
+"checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a026c1436af49d5537c7561c7474f81f7a754e36445fe52e6e88795a9747291c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Lucet version 0.2.1
+# Lucet version 0.2.2
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Lucet version 0.2.2
+# Lucet version 0.3.0
 
 [workspace]
 members = [

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-benchmarks"
-version = "0.2.1"
+version = "0.3.0"
 description = "Benchmarks for the Lucet runtime"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.2.1"
+version = "0.3.0"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.2.1"
+version = "0.3.0"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.6.1"
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.2.2"
+version = "0.3.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 libc = "=0.2.59"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.2.2" }
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.3.0" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
 num-traits = "0.2"
 num-derive = "0.2"
 
@@ -20,9 +20,9 @@ num-derive = "0.2"
 byteorder = "1.2"
 failure = "0.1"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "0.2.1" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.2.1" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
+lucetc = { path = "../lucetc", version = "0.3.0" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.3.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.3.0" }
 nix = "0.13"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 libc = "=0.2.59"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.2.1" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.2.2" }
 lucet-module = { path = "../lucet-module", version = "0.2.1" }
 num-traits = "0.2"
 num-derive = "0.2"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.2.2"
+version = "0.3.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "0.2.1" }
+lucet-module = { path = "../../lucet-module", version = "0.3.0" }
 
 bitflags = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -19,7 +19,7 @@ failure = "0.1"
 lazy_static = "1.1"
 tempfile = "3.0"
 lucet-module = { path = "../../lucet-module", version = "0.2.1" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.2.1" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.2.2" }
 lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.2.1" }
 lucetc = { path = "../../lucetc", version = "0.2.1" }
 

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.2.2"
+version = "0.3.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 failure = "0.1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "0.2.1" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.2.2" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.2.1" }
-lucetc = { path = "../../lucetc", version = "0.2.1" }
+lucet-module = { path = "../../lucet-module", version = "0.3.0" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.3.0" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.3.0" }
+lucetc = { path = "../../lucetc", version = "0.3.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.2.1"
+version = "0.3.0"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,10 +17,10 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "0.2.1" }
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
-lucet-runtime = { path = "../lucet-runtime", version = "0.2.1" }
-wabt = "0.7"
+lucetc = { path = "../lucetc", version = "0.3.0" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.3.0" }
+wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"
 failure = "0.1"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.2.1"
+version = "0.3.0"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,9 +24,9 @@ cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.44.0" 
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.3.0" }
 tempfile = "3.0"
-wabt = "0.7"
+wabt = "0.9.2"
 
 [package.metadata.deb]
 name = "fst-lucet-validate"

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.2.1"
+version = "0.3.0"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.2.1"
+version = "0.3.0"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "0.2.1" }
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucetc = { path = "../lucetc", version = "0.3.0" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
 tempfile = "3.0"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "0.2.1" }
+lucet-validate = { path = "../lucet-validate", version  = "0.3.0" }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.2.1"
+version = "0.3.0"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -29,15 +29,15 @@ clap = "2.23"
 failure = "0.1"
 human-size = "0.4"
 libc = "=0.2.59"
-lucet-runtime = { path = "../lucet-runtime", version = "0.2.1" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.2.1" }
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.3.0" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.3.0" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
 nix = "0.13"
 rand = "0.6"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.2.1" }
-lucetc = { path = "../lucetc", version = "0.2.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.3.0" }
+lucetc = { path = "../lucetc", version = "0.3.0" }
 tempfile = "3.0"
 
 [build-dependencies.bindgen]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.2.2"
+version = "0.3.0"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -26,8 +26,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.44.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.44.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.44.0" }
 target-lexicon = "0.8.0"
-lucet-module = { path = "../lucet-module", version = "0.2.1" }
-lucet-validate = { path = "../lucet-validate", version = "0.2.1" }
+lucet-module = { path = "../lucet-module", version = "0.3.0" }
+lucet-validate = { path = "../lucet-validate", version = "0.3.0" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.2.1"
+version = "0.2.2"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -37,7 +37,7 @@ goblin = "0.0.24"
 failure = "0.1"
 byteorder = "1.2"
 wasmonkey = { path = "../lucet-builtins/wasmonkey", version = "0.1.7" }
-wabt = "0.9.1"
+wabt = "0.9.2"
 tempfile = "3.0"
 bimap = "0.2"
 human-size = "0.4"


### PR DESCRIPTION
Only a few changes since 0.2.1:

* lucetc error messages include the underlying error from wabt
* lucet-runtime supports timeouts
* lucetc can emit errors as json
* lucet-runtime removes unnecessary restrictions on some functions