### PR TITLE
Make it safe to send yielded instances to other threads

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -911,6 +911,11 @@ impl Instance {
 
         self.with_signals_on(|i| {
             HOST_CTX.with(|host_ctx| {
+                unsafe {
+                    let new_host_ctx = &mut *host_ctx.get() as *const _ as u64;
+                    let stack = i.alloc.stack_u64_mut();
+                    stack[stack.len() - 3] = new_host_ctx;
+                };
                 // Save the current context into `host_ctx`, and jump to the guest context. The
                 // lucet context is linked to host_ctx, so it will return here after it finishes,
                 // successfully or otherwise.


### PR DESCRIPTION
Currently we have an implicit assumption that the TLS variable `HOST_CTX` will always point to the same location it pointed to when `Instance::run()` was first called. This assumption used to be fine, because we always used to return from `run()` with a stack that was either empty or unusable (termination or fault). Whenever a user would be in a position to call an `InstanceHandle` from another thread, we'd have to start with a fresh stack.

Not so with yielded instances, which have a stack that we do expect to resume later. If that "later" happens to be on a different thread `HOST_CTX` will point somewhere different from the saved pointer at the base of the guest stack, and things will go wrong when the guest eventually returns through the backstop.

This is an initial pass to add a test to exercise this behavior, and to fix the bug in the most quick-and-dirty way possible. It would be nice to clean this up to something less brittle before merging.