### PR TITLE
Run more test cases per fuzz job

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,4 +45,6 @@ jobs:
       run: make test-fuzz
 
     - name: Fuzz
+      env:
+          FUZZ_NUM_TESTS: 100000
       run: make fuzz

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,10 @@ test-except-fuzz:
 test-fuzz:
 	cargo run -p lucet-wasi-fuzz -- test-seed 410757864950
 
+FUZZ_NUM_TESTS?=1000
 .PHONY: fuzz
 fuzz:
-	cargo run --release -p lucet-wasi-fuzz -- fuzz --num-tests=1000
+	cargo run --release -p lucet-wasi-fuzz -- fuzz --num-tests=$(FUZZ_NUM_TESTS)
 
 .PHONY: bench
 bench:


### PR DESCRIPTION
Run 100k fuzz tests per run of the fuzz job.

Github apparently gives us six hours per job, so we can probably turn this up once we know how long that number takes on their infra.