### PR TITLE
Include CPU features in module data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1012,6 +1013,7 @@ dependencies = [
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test: indent-check test-except-fuzz test-fuzz
 
 .PHONY: test-except-fuzz
 test-except-fuzz:
+	cargo build -p lucet-spectest # build but *not* run spectests to mitigate bitrot while spectests don't pass
 	cargo test --no-fail-fast \
             -p lucet-runtime-internals \
             -p lucet-runtime \

--- a/lucet-module/src/lib.rs
+++ b/lucet-module/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::functions::{
 pub use crate::globals::{Global, GlobalDef, GlobalSpec, GlobalValue};
 pub use crate::linear_memory::{HeapSpec, LinearMemorySpec, SparseData};
 pub use crate::module::{Module, SerializedModule, LUCET_MODULE_SYM};
-pub use crate::module_data::{ModuleData, MODULE_DATA_SYM};
+pub use crate::module_data::{ModuleData, ModuleFeatures, MODULE_DATA_SYM};
 pub use crate::runtime::InstanceRuntimeData;
 pub use crate::signature::{ModuleSignature, PublicKey};
 pub use crate::tables::TableElement;

--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -34,6 +34,38 @@ pub struct ModuleData<'a> {
     export_functions: Vec<ExportFunction<'a>>,
     signatures: Vec<Signature>,
     module_signature: Vec<u8>,
+    features: ModuleFeatures,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ModuleFeatures {
+    pub sse3: bool,
+    pub ssse3: bool,
+    pub sse41: bool,
+    pub sse42: bool,
+    pub avx: bool,
+    pub bmi1: bool,
+    pub bmi2: bool,
+    pub lzcnt: bool,
+    pub popcnt: bool,
+    _hidden: (),
+}
+
+impl ModuleFeatures {
+    pub fn none() -> Self {
+        Self {
+            sse3: false,
+            ssse3: false,
+            sse41: false,
+            sse42: false,
+            avx: false,
+            bmi1: false,
+            bmi2: false,
+            lzcnt: false,
+            popcnt: false,
+            _hidden: (),
+        }
+    }
 }
 
 impl<'a> ModuleData<'a> {
@@ -44,6 +76,7 @@ impl<'a> ModuleData<'a> {
         import_functions: Vec<ImportFunction<'a>>,
         export_functions: Vec<ExportFunction<'a>>,
         signatures: Vec<Signature>,
+        features: ModuleFeatures,
     ) -> Self {
         let module_signature = vec![0u8; SignatureBones::BYTES];
         Self {
@@ -54,6 +87,7 @@ impl<'a> ModuleData<'a> {
             export_functions,
             signatures,
             module_signature,
+            features,
         }
     }
 
@@ -113,6 +147,10 @@ impl<'a> ModuleData<'a> {
         &self.module_signature
     }
 
+    pub fn features(&self) -> &ModuleFeatures {
+        &self.features
+    }
+
     pub fn patch_module_signature(
         module_data_bin: &'a [u8],
         module_signature: &[u8],
@@ -161,6 +199,7 @@ pub struct OwnedModuleData {
     imports: Vec<OwnedImportFunction>,
     exports: Vec<OwnedExportFunction>,
     signatures: Vec<Signature>,
+    features: ModuleFeatures,
 }
 
 impl OwnedModuleData {
@@ -171,6 +210,7 @@ impl OwnedModuleData {
         imports: Vec<OwnedImportFunction>,
         exports: Vec<OwnedExportFunction>,
         signatures: Vec<Signature>,
+        features: ModuleFeatures,
     ) -> Self {
         Self {
             linear_memory,
@@ -179,6 +219,7 @@ impl OwnedModuleData {
             imports,
             exports,
             signatures,
+            features,
         }
     }
 
@@ -199,11 +240,20 @@ impl OwnedModuleData {
             self.imports.iter().map(|imp| imp.to_ref()).collect(),
             self.exports.iter().map(|exp| exp.to_ref()).collect(),
             self.signatures.clone(),
+            self.features.clone(),
         )
     }
 
     pub fn empty() -> Self {
-        Self::new(None, vec![], vec![], vec![], vec![], vec![])
+        Self::new(
+            None,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            ModuleFeatures::none(),
+        )
     }
 
     pub fn with_heap_spec(mut self, heap_spec: HeapSpec) -> Self {

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -24,6 +24,7 @@ nix = "0.13"
 num-derive = "0.2"
 num-traits = "0.2"
 xfailure = "0.1"
+raw-cpuid = "7.0.3"
 
 # This is only a dependency to ensure that other crates don't pick a newer version as a transitive
 # dependency. `0.1.3 < getrandom <= 0.1.6` cause `lazy_static` to pull in spinlock implementations

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -3,8 +3,8 @@ use crate::module::{AddrDetails, GlobalSpec, HeapSpec, Module, ModuleInternal, T
 use libc::c_void;
 use libloading::Library;
 use lucet_module::{
-    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, ModuleSignature,
-    PublicKey, SerializedModule, Signature, VersionInfo, LUCET_MODULE_SYM,
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, ModuleFeatures,
+    ModuleSignature, PublicKey, SerializedModule, Signature, VersionInfo, LUCET_MODULE_SYM,
 };
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
@@ -12,6 +12,65 @@ use std::path::Path;
 use std::slice;
 use std::slice::from_raw_parts;
 use std::sync::Arc;
+
+use raw_cpuid::CpuId;
+
+fn check_feature_support(module_features: &ModuleFeatures) -> Result<(), Error> {
+    let cpuid = CpuId::new();
+
+    fn missing_feature(feature: &str) -> Error {
+        Error::Unsupported(format!(
+            "Module requires feature host does not support: {}",
+            feature
+        ))
+    }
+
+    let info = cpuid
+        .get_feature_info()
+        .ok_or_else(|| Error::Unsupported("Unable to obtain host CPU feature info!".to_string()))?;
+
+    if module_features.sse3 && !info.has_sse3() {
+        return Err(missing_feature("SSE3"));
+    }
+    if module_features.ssse3 && !info.has_ssse3() {
+        return Err(missing_feature("SSS3"));
+    }
+    if module_features.sse41 && !info.has_sse41() {
+        return Err(missing_feature("SSE4.1"));
+    }
+    if module_features.sse42 && !info.has_sse42() {
+        return Err(missing_feature("SSE4.2"));
+    }
+    if module_features.avx && !info.has_avx() {
+        return Err(missing_feature("AVX"));
+    }
+    if module_features.popcnt && !info.has_popcnt() {
+        return Err(missing_feature("POPCNT"));
+    }
+
+    let info = cpuid.get_extended_feature_info().ok_or_else(|| {
+        Error::Unsupported("Unable to obtain host CPU extended feature info!".to_string())
+    })?;
+
+    if module_features.bmi1 && !info.has_bmi1() {
+        return Err(missing_feature("BMI1"));
+    }
+
+    if module_features.bmi2 && !info.has_bmi2() {
+        return Err(missing_feature("BMI2"));
+    }
+
+    let info = cpuid.get_extended_function_info().ok_or_else(|| {
+        Error::Unsupported("Unable to obtain host CPU extended function info!".to_string())
+    })?;
+
+    if module_features.lzcnt && !info.has_lzcnt() {
+        return Err(missing_feature("LZCNT"));
+    }
+
+    // Features are fine, we're compatible!
+    Ok(())
+}
 
 /// A Lucet module backed by a dynamically-loaded shared object.
 pub struct DlModule {
@@ -90,6 +149,8 @@ impl DlModule {
             )
         };
         let module_data = ModuleData::deserialize(module_data_slice)?;
+
+        check_feature_support(module_data.features())?;
 
         // If a public key has been provided, verify the module signature
         // The TOCTOU issue is unavoidable without reimplenting `dlopen(3)`

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -6,8 +6,8 @@ use lucet_module::owned::{
     OwnedLinearMemorySpec, OwnedModuleData, OwnedSparseData,
 };
 use lucet_module::{
-    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, Signature, TrapSite,
-    UniqueSignatureIndex,
+    FunctionHandle, FunctionIndex, FunctionPointer, FunctionSpec, ModuleData, ModuleFeatures,
+    Signature, TrapSite, UniqueSignatureIndex,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -221,6 +221,7 @@ impl MockModuleBuilder {
             self.imports,
             self.exports,
             self.signatures,
+            ModuleFeatures::none(),
         );
         let serialized_module_data = owned_module_data
             .to_ref()

--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -1,7 +1,7 @@
 use crate::bindings;
 use failure::{format_err, Error, Fail};
 use lucet_runtime::{self, MmapRegion, Module as LucetModule, Region, UntypedRetVal, Val};
-use lucetc::{Compiler, HeapSettings, LucetcError, LucetcErrorKind, OptLevel};
+use lucetc::{Compiler, CpuFeatures, HeapSettings, LucetcError, LucetcErrorKind, OptLevel};
 use std::io;
 use std::process::Command;
 use std::sync::Arc;
@@ -70,6 +70,7 @@ impl ScriptEnv {
         let compiler = Compiler::new(
             module,
             OptLevel::default(),
+            CpuFeatures::baseline(),
             &bindings,
             HeapSettings::default(),
             true,

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -43,6 +43,7 @@ minisign = "0.5.11"
 memoffset = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
+raw-cpuid = "7.0.3"
 
 [package.metadata.deb]
 name = "fst-lucetc"

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -135,7 +135,7 @@ impl<'a> Compiler<'a> {
 
     pub fn module_features(&self) -> ModuleFeatures {
         // This will grow in the future to encompass other options describing the compiled module.
-        self.cpu_features.clone().into()
+        (&self.cpu_features).into()
     }
 
     pub fn module_data(&self) -> Result<ModuleData<'_>, LucetcError> {

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -21,7 +21,7 @@ use cranelift_module::{Backend as ClifBackend, Module as ClifModule};
 use cranelift_wasm::{translate_module, FuncTranslator, ModuleTranslationState, WasmError};
 use failure::{format_err, Fail, ResultExt};
 use lucet_module::bindings::Bindings;
-use lucet_module::{FunctionSpec, ModuleData, MODULE_DATA_SYM};
+use lucet_module::{FunctionSpec, ModuleData, ModuleFeatures, MODULE_DATA_SYM};
 use lucet_validate::Validator;
 
 #[derive(Debug, Clone, Copy)]
@@ -133,8 +133,13 @@ impl<'a> Compiler<'a> {
         })
     }
 
+    pub fn module_features(&self) -> ModuleFeatures {
+        // This will grow in the future to encompass other options describing the compiled module.
+        self.cpu_features.clone().into()
+    }
+
     pub fn module_data(&self) -> Result<ModuleData<'_>, LucetcError> {
-        self.decls.get_module_data()
+        self.decls.get_module_data(self.module_features())
     }
 
     pub fn object_file(mut self) -> Result<ObjectFile, LucetcError> {
@@ -165,7 +170,13 @@ impl<'a> Compiler<'a> {
 
         stack_probe::declare_metadata(&mut self.decls, &mut self.clif_module).unwrap();
 
-        let module_data_len = write_module_data(&mut self.clif_module, &self.decls)?;
+        let module_data_bytes = self
+            .module_data()?
+            .serialize()
+            .context(LucetcErrorKind::ModuleData)?;
+        let module_data_len = module_data_bytes.len();
+
+        write_module_data(&mut self.clif_module, module_data_bytes)?;
         write_startfunc_data(&mut self.clif_module, &self.decls)?;
         let table_names = write_table_data(&mut self.clif_module, &self.decls)?;
 
@@ -241,19 +252,12 @@ impl<'a> Compiler<'a> {
 
 fn write_module_data<B: ClifBackend>(
     clif_module: &mut ClifModule<B>,
-    decls: &ModuleDecls<'_>,
-) -> Result<usize, LucetcError> {
+    module_data_bytes: Vec<u8>,
+) -> Result<(), LucetcError> {
     use cranelift_module::{DataContext, Linkage};
 
-    let module_data_serialized: Vec<u8> = decls
-        .get_module_data()?
-        .serialize()
-        .context(LucetcErrorKind::ModuleData)?;
-
-    let module_data_len = module_data_serialized.len();
-
     let mut module_data_ctx = DataContext::new();
-    module_data_ctx.define(module_data_serialized.into_boxed_slice());
+    module_data_ctx.define(module_data_bytes.into_boxed_slice());
 
     let module_data_decl = clif_module
         .declare_data(MODULE_DATA_SYM, Linkage::Local, true, None)
@@ -262,7 +266,7 @@ fn write_module_data<B: ClifBackend>(
         .define_data(module_data_decl, &module_data_ctx)
         .context(LucetcErrorKind::ModuleData)?;
 
-    Ok(module_data_len)
+    Ok(())
 }
 
 fn write_startfunc_data<B: ClifBackend>(

--- a/lucetc/src/compiler/cpu_features.rs
+++ b/lucetc/src/compiler/cpu_features.rs
@@ -1,8 +1,11 @@
 use crate::error::{LucetcError, LucetcErrorKind};
 use cranelift_codegen::{isa, settings::Configurable};
 use failure::{format_err, ResultExt};
-use std::collections::HashMap;
+use lucet_module::ModuleFeatures;
+use std::collections::{HashMap, HashSet};
 use target_lexicon::Triple;
+
+use raw_cpuid::CpuId;
 
 /// x86 CPU families used as shorthand for different CPU feature configurations.
 ///
@@ -64,6 +67,86 @@ pub struct CpuFeatures {
     cpu: TargetCpu,
     /// Specific CPU features to add or remove from the profile
     specific_features: HashMap<SpecificFeature, bool>,
+}
+
+fn detect_features(features: &mut ModuleFeatures) {
+    let cpuid = CpuId::new();
+
+    if let Some(info) = cpuid.get_feature_info() {
+        features.sse3 = info.has_sse3();
+        features.ssse3 = info.has_ssse3();
+        features.sse41 = info.has_sse41();
+        features.sse42 = info.has_sse42();
+        features.avx = info.has_avx();
+        features.popcnt = info.has_popcnt();
+    }
+
+    if let Some(info) = cpuid.get_extended_feature_info() {
+        features.bmi1 = info.has_bmi1();
+        features.bmi2 = info.has_bmi2();
+    }
+
+    if let Some(info) = cpuid.get_extended_function_info() {
+        features.lzcnt = info.has_lzcnt();
+    }
+}
+
+impl Into<ModuleFeatures> for CpuFeatures {
+    fn into(self) -> ModuleFeatures {
+        let mut features = ModuleFeatures::none();
+
+        let mut feature_set: HashSet<SpecificFeature> = HashSet::new();
+
+        if let TargetCpu::Native = self.cpu {
+            // If the target is `Native`, start with the current set of cpu features..
+            detect_features(&mut features);
+        } else {
+            // otherwise, start with the target cpu's default feature set
+            feature_set = self.cpu.features().into_iter().collect();
+        }
+
+        for (feature, enabled) in self.specific_features.iter() {
+            if *enabled {
+                feature_set.insert(*feature);
+            } else {
+                feature_set.remove(feature);
+            }
+        }
+
+        for feature in feature_set {
+            use SpecificFeature::*;
+            match feature {
+                SSE3 => {
+                    features.sse3 = true;
+                }
+                SSSE3 => {
+                    features.ssse3 = true;
+                }
+                SSE41 => {
+                    features.sse41 = true;
+                }
+                SSE42 => {
+                    features.sse42 = true;
+                }
+                AVX => {
+                    features.avx = true;
+                }
+                BMI1 => {
+                    features.bmi1 = true;
+                }
+                BMI2 => {
+                    features.bmi2 = true;
+                }
+                Popcnt => {
+                    features.popcnt = true;
+                }
+                Lzcnt => {
+                    features.lzcnt = true;
+                }
+            }
+        }
+        features
+    }
 }
 
 impl Default for CpuFeatures {

--- a/lucetc/src/compiler/cpu_features.rs
+++ b/lucetc/src/compiler/cpu_features.rs
@@ -91,21 +91,21 @@ fn detect_features(features: &mut ModuleFeatures) {
     }
 }
 
-impl Into<ModuleFeatures> for CpuFeatures {
-    fn into(self) -> ModuleFeatures {
-        let mut features = ModuleFeatures::none();
+impl From<&CpuFeatures> for ModuleFeatures {
+    fn from(cpu_features: &CpuFeatures) -> ModuleFeatures {
+        let mut module_features = ModuleFeatures::none();
 
         let mut feature_set: HashSet<SpecificFeature> = HashSet::new();
 
-        if let TargetCpu::Native = self.cpu {
+        if let TargetCpu::Native = cpu_features.cpu {
             // If the target is `Native`, start with the current set of cpu features..
-            detect_features(&mut features);
+            detect_features(&mut module_features);
         } else {
             // otherwise, start with the target cpu's default feature set
-            feature_set = self.cpu.features().into_iter().collect();
+            feature_set = cpu_features.cpu.features().into_iter().collect();
         }
 
-        for (feature, enabled) in self.specific_features.iter() {
+        for (feature, enabled) in cpu_features.specific_features.iter() {
             if *enabled {
                 feature_set.insert(*feature);
             } else {
@@ -117,35 +117,35 @@ impl Into<ModuleFeatures> for CpuFeatures {
             use SpecificFeature::*;
             match feature {
                 SSE3 => {
-                    features.sse3 = true;
+                    module_features.sse3 = true;
                 }
                 SSSE3 => {
-                    features.ssse3 = true;
+                    module_features.ssse3 = true;
                 }
                 SSE41 => {
-                    features.sse41 = true;
+                    module_features.sse41 = true;
                 }
                 SSE42 => {
-                    features.sse42 = true;
+                    module_features.sse42 = true;
                 }
                 AVX => {
-                    features.avx = true;
+                    module_features.avx = true;
                 }
                 BMI1 => {
-                    features.bmi1 = true;
+                    module_features.bmi1 = true;
                 }
                 BMI2 => {
-                    features.bmi2 = true;
+                    module_features.bmi2 = true;
                 }
                 Popcnt => {
-                    features.popcnt = true;
+                    module_features.popcnt = true;
                 }
                 Lzcnt => {
-                    features.lzcnt = true;
+                    module_features.lzcnt = true;
                 }
             }
         }
-        features
+        module_features
     }
 }
 

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -16,6 +16,7 @@ use cranelift_wasm::{
 };
 use failure::{format_err, Error, ResultExt};
 use lucet_module::bindings::Bindings;
+use lucet_module::ModuleFeatures;
 use lucet_module::{
     owned::OwnedLinearMemorySpec, ExportFunction, FunctionIndex as LucetFunctionIndex,
     FunctionMetadata, Global as GlobalVariant, GlobalDef, GlobalSpec, HeapSpec, ImportFunction,
@@ -502,7 +503,7 @@ impl<'a> ModuleDecls<'a> {
         }
     }
 
-    pub fn get_module_data(&self) -> Result<ModuleData<'_>, LucetcError> {
+    pub fn get_module_data(&self, features: ModuleFeatures) -> Result<ModuleData<'_>, LucetcError> {
         let linear_memory = if let Some(ref spec) = self.linear_memory_spec {
             Some(spec.to_ref())
         } else {
@@ -548,6 +549,7 @@ impl<'a> ModuleDecls<'a> {
             self.imports.clone(),
             self.exports.clone(),
             signatures,
+            features,
         ))
     }
 }


### PR DESCRIPTION
In theory if a module is built with features the runtime doesn't support, the runtime will fail to load the module with a descriptive error.

"In theory" because I don't have a test for this, although it seems correct - I could be convinced to add a test-only feature in lucetc so we can write a test around missing features being rejected, but because each feature is hand-specified, even that's a little brittle. Comments and opinions encouraged, as it's very much not my favorite code.

Also fixes lucet-spectest bitrot and adds a build of it to `make test`.