### PR TITLE
replace lucet_runtime ensure_linked in lucet-wasi

### DIFF
--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -39,6 +39,7 @@ fn parse_humansized(desc: &str) -> Result<u64, Error> {
 fn main() {
     // No-ops, but makes sure the linker doesn't throw away parts
     // of the runtime:
+    lucet_runtime::lucet_internal_ensure_linked();
     lucet_wasi::export_wasi_funcs();
 
     let matches = app_from_crate!()


### PR DESCRIPTION
fixes https://github.com/fastly/lucet/issues/360 where the runtime's C
API was being discarded by the linker.

This load-bearing no-op was removed in https://github.com/fastly/lucet/commit/42f6015b3aa72f28178308160aabf8f13757eb05#diff-73b027b3e246720be89ae930ae180a18L42, which looks accidental in moving around wasi exports?